### PR TITLE
Run only tests + docs on PR or workflow dispatch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,5 @@
 name: docs
-on: [push, pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: pytest
-on: [push]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   build:


### PR DESCRIPTION
Currently the docs are compiled both on PR and on push. Such that if one pushes and creates a PR the docs are compiled twice.

Instead, this sets it up so docs and tests are only run when a PR is created or updated.  It is also possible to manually run tests/docs using the workflow dispatch.