### PR TITLE
Automatically detect name of density

### DIFF
--- a/cuqi/config.py
+++ b/cuqi/config.py
@@ -7,5 +7,5 @@ MAX_DIM_INV = 2000
 DEFAULT_SEED = 0
 """ Default seed for random number generators. """
 
-STACK_SEARCH_DEPTH = 5
-""" Default depth to search the Python variable stack for the name of a density if not set."""
+MAX_STACK_SEARCH_DEPTH = 1000
+""" Maximum depth to search the Python variable stack for the name of a density if not set."""

--- a/cuqi/config.py
+++ b/cuqi/config.py
@@ -6,3 +6,6 @@ MAX_DIM_INV = 2000
 
 DEFAULT_SEED = 0
 """ Default seed for random number generators. """
+
+STACK_SEARCH_DEPTH = 5
+""" Default depth to search the Python variable stack for the name of a density if not set."""

--- a/cuqi/density/_density.py
+++ b/cuqi/density/_density.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Optional
+import cuqi
 
 class Density(ABC):
     """ Abstract base class for densities.

--- a/cuqi/density/_density.py
+++ b/cuqi/density/_density.py
@@ -106,7 +106,12 @@ class Density(ABC):
         return new_density
 
     def __call__(self, *args, **kwargs):
-        """ Condition on the given parameters. """
+        """ Condition the density on a set of parameters.
+        
+        Positional arguments must follow the order of the parameter names.
+        These can be accessed via the :meth:`get_parameter_names` method.
+        
+        """
         return self._condition(*args, **kwargs)
 
 class EvaluatedDensity(Density):

--- a/cuqi/density/_density.py
+++ b/cuqi/density/_density.py
@@ -39,7 +39,7 @@ class Density(ABC):
         if self._is_copy: # Extract the original density name
             return self._original_density.name
         if self._name is None: # If none extract the name from the stack
-            self._name = cuqi.utilities.get_python_variable_name(self)
+            self._name = cuqi.utilities._get_python_variable_name(self)
         return self._name
 
     @name.setter

--- a/cuqi/density/_density.py
+++ b/cuqi/density/_density.py
@@ -3,7 +3,6 @@ from abc import ABC, abstractmethod
 from typing import Optional
 from copy import copy
 import cuqi
-import ctypes
 
 class Density(ABC):
     """ Abstract base class for densities.

--- a/cuqi/density/_density.py
+++ b/cuqi/density/_density.py
@@ -31,14 +31,14 @@ class Density(ABC):
             raise ValueError(f"{self.__init__.__qualname__}: Name must be a string or None")
         self.name = name
         self._constant = 0 # Precomputed constant to add to the log probability.
-        self._original_density = None # Original density if this is a conditioned copy.
+        self._original_density = None # Original density if this is a conditioned copy. Used to extract name.
 
     @property
     def name(self):
         """ Name of the random variable associated with the density. """
         if self._is_copy: # Extract the original density name
             return self._original_density.name
-        if self._name is None: # If none extract the name from the stack
+        if self._name is None: # If None extract the name from the stack
             self._name = cuqi.utilities._get_python_variable_name(self)
         return self._name
 
@@ -50,7 +50,7 @@ class Density(ABC):
 
     @property
     def _is_copy(self):
-        """ Returns True if this is a copy of another density. """
+        """ Returns True if this is a copy of another density, e.g. by conditioning. """
         return hasattr(self, '_original_density') and self._original_density is not None
 
     def logd(self, *args, **kwargs):
@@ -99,7 +99,6 @@ class Density(ABC):
 
     def _make_copy(self):
         """ Returns a shallow copy of the density keeping a pointer to the original. """
-        # Store id of original density
         new_density = copy(self)
         new_density._original_density = self
         return new_density
@@ -109,6 +108,8 @@ class Density(ABC):
         
         Positional arguments must follow the order of the parameter names.
         These can be accessed via the :meth:`get_parameter_names` method.
+
+        Conditioning maintains the name of the random variable associated with the density.
         
         """
         return self._condition(*args, **kwargs)

--- a/cuqi/density/_density.py
+++ b/cuqi/density/_density.py
@@ -30,6 +30,18 @@ class Density(ABC):
         self.name = name
         self._constant = 0 # Precomputed constant to add to the log probability.
 
+    @property
+    def name(self):
+        """ Name of the random variable associated with the density. """
+        if self._name is None: # If none extract the name from the stack
+            name = cuqi.utilities.get_python_variable_name(self)
+            self._name = name
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        self._name = name
+
     def logd(self, *args, **kwargs):
         """ Evaluates the un-normalized log density function given a set of parameters.
         
@@ -38,14 +50,14 @@ class Density(ABC):
         
         """
 
-        # Get parameter names possible to evaluate the logd
-        par_names = self.get_parameter_names()
-
         # Check if kwargs are given. If so parse them according to the parameter names and add them to args.
         if len(kwargs) > 0:
 
             if len(args) > 0:
                 raise ValueError(f"{self.logd.__qualname__}: Cannot specify both positional and keyword arguments.")
+
+            # Get parameter names possible to evaluate the logd
+            par_names = self.get_parameter_names()
 
             # Check if parameter names match the keyword arguments (any order).
             if set(par_names) != set(kwargs.keys()):
@@ -53,10 +65,6 @@ class Density(ABC):
             
             # Ensure that the keyword arguments are given in the correct order and use them as positional arguments.
             args = [kwargs[name] for name in par_names]            
-
-        # Check if the number of arguments matches the number of parameters.
-        if len(args) != len(par_names):
-            raise ValueError(f"{self.logd.__qualname__}: Number of arguments must match number of parameters. Got {len(args)} arguments but density has {len(par_names)} parameters.")
 
         return self._logd(*args) + self._constant
    

--- a/cuqi/distribution/_distribution.py
+++ b/cuqi/distribution/_distribution.py
@@ -231,7 +231,7 @@ class Distribution(Density, ABC):
 
 
         # EVALUATE CONDITIONAL DISTRIBUTION
-        new_dist = copy(self) #New cuqi distribution conditioned on the kwargs
+        new_dist = self._make_copy() #New cuqi distribution conditioned on the kwargs
         processed_kwargs = set() # Keep track of processed (unique) elements in kwargs
 
         # Go through every mutable variable and assign value from kwargs if present

--- a/cuqi/distribution/_distribution.py
+++ b/cuqi/distribution/_distribution.py
@@ -211,7 +211,12 @@ class Distribution(Density, ABC):
         return np.exp(self.logpdf(x))
 
     def _condition(self, *args, **kwargs):
-        """ Generate new distribution conditioned on the input arguments. """
+        """ Generate new distribution conditioned on the input arguments.
+        
+        Positional arguments must follow the order of the parameter names of the distribution.
+        These can be accessed via the :meth:`get_parameter_names` method.
+        
+        """
 
         # Store conditioning variables and mutable variables
         cond_vars = self.get_conditioning_variables()

--- a/cuqi/distribution/_distribution.py
+++ b/cuqi/distribution/_distribution.py
@@ -159,12 +159,12 @@ class Distribution(Density, ABC):
             new_dist = self(**cond_kwargs)
 
             # Evaluate the log density of the conditioned distribution
+            # We use _main_parameter to avoid extracting the name if not necessary
             if "_main_parameter" in kwargs:
                 return new_dist.logd(kwargs["_main_parameter"])
             else:
-                # Extract any remaining variables from kwargs and evaluate the log density
-                non_cond_kwargs = {key: kwargs[key] for key in kwargs if key not in cond_vars}
-                return new_dist.logd(**non_cond_kwargs)
+                main_params = {key: kwargs[key] for key in kwargs if key not in cond_vars}
+                return new_dist.logd(**main_params)
 
         # Not conditional distribution, simply evaluate log density directly
         else:

--- a/cuqi/distribution/_posterior.py
+++ b/cuqi/distribution/_posterior.py
@@ -30,6 +30,12 @@ class Posterior(Distribution):
     gradient: evaluate the gradient of the log probability density function w.r.t. input parameter.
     """
     def __init__(self, likelihood, prior, **kwargs):
+
+        if len(likelihood.get_parameter_names()) > 1:
+            raise ValueError("Likelihood must only have one parameter.")
+        if prior.is_cond:
+            raise ValueError("Prior must not be a conditional distribution.")
+
         self.likelihood = likelihood
         self.prior = prior 
         super().__init__(**kwargs)

--- a/cuqi/distribution/_posterior.py
+++ b/cuqi/distribution/_posterior.py
@@ -78,9 +78,15 @@ class Posterior(Distribution):
         else:
             self._geometry = self.prior.geometry
             
-    def logpdf(self, x):
+    def logpdf(self, *args, **kwargs):
         """ Returns the logpdf of the posterior distribution"""
-        return self.likelihood.logd(x)+ self.prior.logd(x)
+        return self.likelihood.logd(*args, **kwargs)+ self.prior.logd(*args, **kwargs)
+
+    def get_conditioning_variables(self):
+        return self.prior.get_conditioning_variables()
+
+    def get_parameter_names(self):
+        return self.prior.get_parameter_names()
 
     def gradient(self, x):
         #Avoid complicated geometries that change the gradient.

--- a/cuqi/utilities/__init__.py
+++ b/cuqi/utilities/__init__.py
@@ -11,3 +11,5 @@ from ._utilities import (
     sparse_cholesky,
     approx_derivative,
 )
+
+from ._get_python_variable_name import get_python_variable_name

--- a/cuqi/utilities/__init__.py
+++ b/cuqi/utilities/__init__.py
@@ -12,4 +12,4 @@ from ._utilities import (
     approx_derivative,
 )
 
-from ._get_python_variable_name import get_python_variable_name
+from ._get_python_variable_name import _get_python_variable_name

--- a/cuqi/utilities/_get_python_variable_name.py
+++ b/cuqi/utilities/_get_python_variable_name.py
@@ -13,7 +13,7 @@ def _get_python_variable_name(var):
 
     # First get the stack size and loop (in reverse) through the stack
     # It can be a bit slow to loop through stack size so we limit the levels
-    stack_size = stack_size2a() 
+    stack_size = _stack_size2a() 
 
     for i in reversed(range(min(stack_size, cuqi.config.MAX_STACK_SEARCH_DEPTH))): 
 
@@ -34,7 +34,7 @@ def _get_python_variable_name(var):
     return None
 
 #https://stackoverflow.com/questions/34115298/how-do-i-get-the-current-depth-of-the-python-interpreter-stack
-def stack_size2a(size=2):
+def _stack_size2a(size=2):
     """Get stack size for caller's frame.
     """
     frame = sys._getframe(size)

--- a/cuqi/utilities/_get_python_variable_name.py
+++ b/cuqi/utilities/_get_python_variable_name.py
@@ -2,6 +2,8 @@ import sys
 from itertools import count
 import re
 
+import cuqi
+
 
 def get_python_variable_name(var):
     """ Retrieve the Python variable name of an object. Takes the first variable name appearing on the stack that are not in the ignore list. """
@@ -9,10 +11,10 @@ def get_python_variable_name(var):
     ignored_var_names = ["self", "cls", "obj", "var", "_"]
 
     # First get the stack size and loop (in reverse) through the stack
-    # It can be a bit slow to loop through stack size so we limit to 5 levels
+    # It can be a bit slow to loop through stack size so we limit the levels
     #stack_size = stack_size2a() 
 
-    for i in range(5): 
+    for i in range(cuqi.config.STACK_SEARCH_DEPTH): 
 
         # For each frame we look for a variable name matching the object (var)
         local_vars = sys._getframe(i).f_locals.items()

--- a/cuqi/utilities/_get_python_variable_name.py
+++ b/cuqi/utilities/_get_python_variable_name.py
@@ -2,6 +2,7 @@ import sys
 from itertools import count
 import re
 
+import warnings
 import cuqi
 
 
@@ -12,9 +13,9 @@ def get_python_variable_name(var):
 
     # First get the stack size and loop (in reverse) through the stack
     # It can be a bit slow to loop through stack size so we limit the levels
-    #stack_size = stack_size2a() 
+    stack_size = stack_size2a() 
 
-    for i in range(cuqi.config.STACK_SEARCH_DEPTH): 
+    for i in range(min(stack_size, cuqi.config.MAX_STACK_SEARCH_DEPTH)): 
 
         # For each frame we look for a variable name matching the object (var)
         local_vars = sys._getframe(i).f_locals.items()
@@ -26,8 +27,9 @@ def get_python_variable_name(var):
             var_names = [var_name for var_name in var_names if not any([re.match(ignore_var_name, var_name) for ignore_var_name in ignored_var_names])]
             
             if len(var_names) > 0:
-                #print(i)
                 return var_names[0]
+
+    warnings.warn("Could not automatically find variable name for object: {}. If code runs slowly and variable name is not needed set config.MAX_STACK_SEARCH_DEPTH to 0.".format(var))
 
     return None
 

--- a/cuqi/utilities/_get_python_variable_name.py
+++ b/cuqi/utilities/_get_python_variable_name.py
@@ -15,7 +15,7 @@ def get_python_variable_name(var):
     # It can be a bit slow to loop through stack size so we limit the levels
     stack_size = stack_size2a() 
 
-    for i in range(min(stack_size, cuqi.config.MAX_STACK_SEARCH_DEPTH)): 
+    for i in reversed(range(min(stack_size, cuqi.config.MAX_STACK_SEARCH_DEPTH))): 
 
         # For each frame we look for a variable name matching the object (var)
         local_vars = sys._getframe(i).f_locals.items()

--- a/cuqi/utilities/_get_python_variable_name.py
+++ b/cuqi/utilities/_get_python_variable_name.py
@@ -29,7 +29,7 @@ def _get_python_variable_name(var):
             if len(var_names) > 0:
                 return var_names[0]
 
-    warnings.warn("Could not automatically find variable name for object: {}. If code runs slowly and variable name is not needed set config.MAX_STACK_SEARCH_DEPTH to 0.".format(var))
+    warnings.warn("Could not automatically find variable name for object: {}. Use keyword `name` when defining distribution to specify a name. If code runs slowly and variable name is not needed set config.MAX_STACK_SEARCH_DEPTH to 0.".format(var))
 
     return None
 

--- a/cuqi/utilities/_get_python_variable_name.py
+++ b/cuqi/utilities/_get_python_variable_name.py
@@ -6,7 +6,7 @@ import warnings
 import cuqi
 
 
-def get_python_variable_name(var):
+def _get_python_variable_name(var):
     """ Retrieve the Python variable name of an object. Takes the first variable name appearing on the stack that are not in the ignore list. """
 
     ignored_var_names = ["self", "cls", "obj", "var", "_"]

--- a/cuqi/utilities/_get_python_variable_name.py
+++ b/cuqi/utilities/_get_python_variable_name.py
@@ -1,0 +1,41 @@
+import sys
+from itertools import count
+import re
+
+
+def get_python_variable_name(var):
+    """ Retrieve the Python variable name of an object. Takes the first variable name appearing on the stack that are not in the ignore list. """
+
+    ignored_var_names = ["self", "cls", "obj", "var", "_"]
+
+    # First get the stack size and loop (in reverse) through the stack
+    # It can be a bit slow to loop through stack size so we limit to 5 levels
+    #stack_size = stack_size2a() 
+
+    for i in range(5): 
+
+        # For each frame we look for a variable name matching the object (var)
+        local_vars = sys._getframe(i).f_locals.items()
+        var_names = [var_name for var_name, var_val in local_vars if var_val is var]
+
+        # If we find a matching variable name we return it if it is not in the ignore list
+        if len(var_names) > 0:
+            # Get variable names not regex matching the ignore list
+            var_names = [var_name for var_name in var_names if not any([re.match(ignore_var_name, var_name) for ignore_var_name in ignored_var_names])]
+            
+            if len(var_names) > 0:
+                #print(i)
+                return var_names[0]
+
+    return None
+
+#https://stackoverflow.com/questions/34115298/how-do-i-get-the-current-depth-of-the-python-interpreter-stack
+def stack_size2a(size=2):
+    """Get stack size for caller's frame.
+    """
+    frame = sys._getframe(size)
+
+    for size in count(size):
+        frame = frame.f_back
+        if not frame:
+            return size

--- a/cuqi/utilities/_get_python_variable_name.py
+++ b/cuqi/utilities/_get_python_variable_name.py
@@ -7,7 +7,7 @@ import cuqi
 
 
 def _get_python_variable_name(var):
-    """ Retrieve the Python variable name of an object. Takes the first variable name appearing on the stack that are not in the ignore list. """
+    """ Retrieve the Python variable name of an object. Takes the first variable name appearing on the stack that is not in the ignore list. """
 
     ignored_var_names = ["self", "cls", "obj", "var", "_"]
 

--- a/tests/test_abstract_distribution_density.py
+++ b/tests/test_abstract_distribution_density.py
@@ -43,10 +43,10 @@ def test_conditioning_on_main_parameter():
 
     # With keywords (name also automatically inferred)
     assert isinstance(x(mean=1, x=5), cuqi.likelihood.Likelihood)
-    assert isinstance(x(mean=1, cov=1, x=5), cuqi.density.ConstantDensity)
+    assert isinstance(x(mean=1, cov=1, x=5), cuqi.density.EvaluatedDensity)
     
     # Now using positional arguments
-    assert isinstance(x(1, 1, 5), cuqi.density.ConstantDensity)
+    assert isinstance(x(1, 1, 5), cuqi.density.EvaluatedDensity)
 
 def test_conditioning_kwarg_as_mutable_var():
     """ This checks if we allow kwargs for a distribution that has no conditioning variables. """

--- a/tests/test_abstract_distribution_density.py
+++ b/tests/test_abstract_distribution_density.py
@@ -135,13 +135,3 @@ def test_logd_err_handling():
     with pytest.raises(ValueError, match=r"(?i)positional"):
         x.logd(3, s=7, x=13)
 
-    # Test if we pass wrong number of arguments
-    with pytest.raises(ValueError, match=r"Number of arguments must match"):
-        y = x(x=13) #Condition on x to make it likelihood
-
-        # Pass too many arguments
-        y.logd(3, 7, 100)
-
-        # Pass too few arguments
-        y.logd(3)
-

--- a/tests/test_abstract_distribution_density.py
+++ b/tests/test_abstract_distribution_density.py
@@ -32,10 +32,21 @@ def test_conditioning_wrong_keyword():
         x(name="hey") #Should expect value-error since name not conditioning variable.
 
 def test_conditioning_arg_as_mutable_var():
-    """ This checks if we raise error if arg is given for a distribution that has no conditioning variables. """
+    """ This checks if we raise error if 2 args is given for a distribution that has no conditioning variables. """
     x = cuqi.distribution.GaussianCov(mean=1, cov=1)
     with pytest.raises(ValueError):
-        x(5) #Should expect value-error since no cond vars
+        x(5, 3) #Should expect value-error since no cond vars
+
+def test_conditioning_on_main_parameter():
+    """ This checks if we can condition on the main parameter in various ways. """
+    x = cuqi.distribution.GaussianCov()
+
+    # With keywords (name also automatically inferred)
+    assert isinstance(x(mean=1, x=5), cuqi.likelihood.Likelihood)
+    assert isinstance(x(mean=1, cov=1, x=5), cuqi.density.ConstantDensity)
+    
+    # Now using positional arguments
+    assert isinstance(x(1, 1, 5), cuqi.density.ConstantDensity)
 
 def test_conditioning_kwarg_as_mutable_var():
     """ This checks if we allow kwargs for a distribution that has no conditioning variables. """

--- a/tests/test_abstract_distribution_density.py
+++ b/tests/test_abstract_distribution_density.py
@@ -32,7 +32,7 @@ def test_conditioning_wrong_keyword():
         x(name="hey") #Should expect value-error since name not conditioning variable.
 
 def test_conditioning_arg_as_mutable_var():
-    """ This checks if we raise error if 2 args is given for a distribution that has no conditioning variables. """
+    """ This checks if we raise error if 2 args are given for a distribution that has no conditioning variables. """
     x = cuqi.distribution.GaussianCov(mean=1, cov=1)
     with pytest.raises(ValueError):
         x(5, 3) #Should expect value-error since no cond vars

--- a/tests/test_abstract_distribution_density.py
+++ b/tests/test_abstract_distribution_density.py
@@ -75,7 +75,7 @@ def test_conditioning_partial_function():
 
 def test_conditioning_keeps_name():
     """ This tests if the name of the distribution is kept when conditioning. """
-    y = cuqi.distribution.GaussianCov(lambda x:x, name="y")
+    y = cuqi.distribution.GaussianCov(lambda x:x)
     
     assert y(x=1, cov=1).name == y.name
     assert y(x=1)(cov=1).name == y.name
@@ -89,7 +89,7 @@ def test_conditioning_class_flow():
     """ This tests the class flow of conditioning a conditional distribution in various ways """
 
     # Initial conditional distribution on parameter x and cov.
-    y = cuqi.distribution.GaussianCov(lambda x:x, name="y")
+    y = cuqi.distribution.GaussianCov(lambda x:x)
 
     # Conditioning on x is still conditional on cov
     assert y(x=1).is_cond
@@ -118,7 +118,7 @@ def test_logp_conditional():
     true_val = cuqi.distribution.GaussianCov(3, 7).logd(13)
 
     # Distribution with no specified parameters
-    x = cuqi.distribution.GaussianCov(cov=lambda s:s, name="x") # TODO: Remove name attribute once it can be inferred from variable
+    x = cuqi.distribution.GaussianCov(cov=lambda s:s)
 
     # Test logp evaluates correctly in various cases
     assert x.logd(mean=3, s=7, x=13) == true_val
@@ -131,7 +131,7 @@ def test_logp_conditional():
 
 def test_logd_err_handling():
     """ This tests if logp correctly identifies errors in the input """
-    x = cuqi.distribution.GaussianCov(cov=lambda s:s, name="x") # TODO: Remove name attribute once it can be inferred from variable
+    x = cuqi.distribution.GaussianCov(cov=lambda s:s)
 
     # Test that we raise error if we don't provide all parameters
     with pytest.raises(ValueError, match=r"To evaluate the log density all conditioning variables must be specified"):
@@ -141,8 +141,47 @@ def test_logd_err_handling():
     with pytest.raises(ValueError, match=r"do not match keyword arguments"):
         x.logd(mean=3, s=7, x=13, y=1)
 
-    # Test that we raise error if provided with both positional and keyword arguments
-    # Regex on word "positional" in both lower or upper case
-    with pytest.raises(ValueError, match=r"(?i)positional"):
-        x.logd(3, s=7, x=13)
+def test_cond_positional_and_kwargs():
+    """ Test conditioning for both positional and kwargs """
+    x = cuqi.distribution.GaussianCov(cov=lambda s:s)
+
+    logd = x(mean=3, cov=7).logd(13)
+
+    # Conditioning full positional
+    assert x(3, 7, 13).value == logd
+    assert x(3, 7)(13).value == logd
+    assert x(3)(7, 13).value == logd
+    assert x(3)(7)(13).value == logd
+
+    # Conditioning full kwargs
+    assert x(mean=3, cov=7, x=13).value == logd
+    assert x(mean=3, cov=7)(x=13).value == logd
+    assert x(mean=3)(cov=7, x=13).value == logd
+    assert x(mean=3)(cov=7)(x=13).value == logd
+
+    # Conditioning partial positional
+    assert x(3, s=7, x=13).value == logd
+    assert x(3, 7, x=13).value == logd
+    assert x(3, s=7)(13).value == logd
+    assert x(mean=3)(7, x=13).value == logd
+    assert x(mean=3)(7)(x=13).value == logd
+    assert x(mean=3)(7)(13).value == logd
+
+def test_logd_positional_and_kwargs():
+    """ Test logd for both positional and kwargs """
+    x = cuqi.distribution.GaussianCov(cov=lambda s:s)
+
+    logd = x(mean=3, s=7).logd(13)
+
+    # logd full kwargs
+    assert x.logd(mean=3, s=7, x=13) == logd
+
+    # logd full positional
+    assert x.logd(3, 7, 13) == logd
+
+    # logd partial positional
+    assert x.logd(3, s=7, x=13) == logd
+    assert x.logd(3, 7, x=13) == logd
+
+
 

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -30,11 +30,11 @@ def test_variable_name_accross_frames():
 
     h = cuqi.distribution.GaussianCov() # Name should be 'h'
 
-    def recursive_return_dist(_dist, recursions):
+    def recursive_return_dist(dist, recursions):
         if recursions == 0:
-            assert _dist.name == 'h' # h was defined many frames above, and name should be inferred correctly.
+            assert dist.name == 'h' # h was defined many frames above, and name should be inferred correctly.
         else:
-            recursive_return_dist(_dist, recursions - 1)
+            recursive_return_dist(dist, recursions - 1)
     
     recursive_return_dist(h, 10)
 

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -1,0 +1,28 @@
+import cuqi
+
+def test_density_variable_name_detection():
+    """Test that the density variable name is detected correctly at different levels of the python stack. """
+
+    # Test that the density variable name is detected correctly at current level.
+    x = cuqi.distribution.GaussianCov()
+    assert x.name == 'x'
+
+    # Test that variable name is detected correctly 1 level deep.
+    def inner_name():
+        y = cuqi.distribution.GaussianCov()
+        assert y.name == 'y'
+    inner_name()
+
+    # Test variable name is detected correctly at n levels deep.
+    class recursive_name:
+        def __init__(self, max_recursion=10):
+            self.max_recursion = max_recursion
+        def __call__(self, current_recursion=0):
+            if current_recursion == self.max_recursion:
+                z = cuqi.distribution.GaussianCov()
+                assert z.name == 'z'
+            else:
+                self(current_recursion + 1)
+    recursive_name()()
+
+    

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -25,4 +25,18 @@ def test_density_variable_name_detection():
                 self(current_recursion + 1)
     recursive_name()()
 
+def test_variable_name_accross_frames():
+    """ Test variable name can be inferred across multiple stack frames. """
+
+    h = cuqi.distribution.GaussianCov() # Name should be 'h'
+
+    def recursive_return_dist(_dist, recursions):
+        if recursions == 0:
+            assert _dist.name == 'h' # h was defined many frames above, and name should be inferred correctly.
+        else:
+            recursive_return_dist(_dist, recursions - 1)
+    
+    recursive_return_dist(h, 10)
+
+
     

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -1,4 +1,5 @@
 import cuqi
+import pytest
 
 def test_density_variable_name_detection():
     """Test that the density variable name is detected correctly at different levels of the python stack. """
@@ -37,6 +38,29 @@ def test_variable_name_accross_frames():
             recursive_return_dist(dist, recursions - 1)
     
     recursive_return_dist(h, 10)
+
+def test_density_name_consistency():
+
+    x = cuqi.distribution.GaussianCov()
+    x2 = x(mean=1)
+    x3 = x2(cov=1)
+
+    # Names should be the same as the original density.  
+    assert x3.name == 'x'
+    assert x2.name == 'x' 
+    assert x.name == 'x'
+
+    # Ensure that the name cannot be changed for conditioned densities.
+    with pytest.raises(ValueError, match=r"Cannot set name of conditioned density. Only the original density can have its name set."):
+        x2.name = 'y'
+
+    x.name = 'y'
+
+    # Ensure that the name is changed for the other conditioned densities.
+    assert x2.name == 'y'
+    assert x3.name == 'y'
+    
+
 
 
     

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -108,4 +108,4 @@ def test_likelihood_conditioning(dist, mean, cov, data):
     # Now compare log when conditioning on 3 cases: mean, cov, both
     assert likelihood(**mean_dict).logd(**cov_dict) == log_val
     assert likelihood(**cov_dict).logd(**mean_dict) == log_val
-    assert likelihood(**param_dict).logd() == log_val
+    assert likelihood(**param_dict).logd() == log_val # This becomes EvaluatedDensity. Throws warning on the stack size (since we pass name to EvaluatedDensity)


### PR DESCRIPTION
Closes #20 

Currently the user has the write the following code to define a random variable following a distribution e,g, `x ~ N(0,1)` 

``` Python
x = GaussianCov(0, 1, name="x") 
```
With this update the user can write
``` Python
x = GaussianCov(0, 1)
```
and the name is automatically determined.

It required a bit of optimization and restructuring of the _condition method for distributions to make it work cleanly without too much overhead. After further discussion we also made the options for evaluating the logd and conditioning with positional and kwargs more consistent.

- [x] Added method for automatically determining python variable name of a density
- [x] Added tests
- [x] Added optimizations on conditioning for distributions to make it run faster (no functional change) 
- [x] Added functionality for evaluating with positions or kwargs