### PR TITLE
Run workflows on push to main branch (after a PR merge)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,12 @@
 name: docs
-on: [pull_request, workflow_dispatch]
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,11 @@
 name: pytest
-on: [pull_request, workflow_dispatch]
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Closes #24 

Hi @amal-ghamdi, @jakobsj. This is a very minor PR that fixes an important issue that the docs and tests were not running automatically after PR merge into main.