### PR TITLE
Sprint 11 Remove allow reduce flag for joint distribution

### DIFF
--- a/cuqi/distribution/_joint_distribution.py
+++ b/cuqi/distribution/_joint_distribution.py
@@ -67,7 +67,6 @@ class JointDistribution:
             raise ValueError("All densities must have unique names.")
 
         self._densities = list(densities)
-        self._allow_reduce = False # Hack to allow conditioning to reduce a joint distribution to a single density
 
         # Make sure every parameter has a distribution (prior)
         cond_vars = self._get_conditioning_variables()
@@ -120,14 +119,10 @@ class JointDistribution:
             cond_kwargs = {key:value for (key,value) in kwargs.items() if key in density.get_parameter_names()}
             new_joint._densities[i] = density(**cond_kwargs)
 
-        # Hack to reduce the joint distribution to a single density
-        # This is useful for current implementation of our samplers
-        # but should be removed in the future. Should only be used
-        # by the Gibbs sampler.
-        if self._allow_reduce:
-            return new_joint._reduce_to_single_density()
-
-        return new_joint
+        # Potentially reduce joint distribution to a single density
+        # This happens if there is only a single parameter left.
+        # Can reduce to Posterior, Likelihood or Distribution.
+        return new_joint._reduce_to_single_density()
 
     def get_parameter_names(self) -> List[str]:
         """ Returns the parameter names of the joint distribution. """

--- a/cuqi/sampler/_gibbs.py
+++ b/cuqi/sampler/_gibbs.py
@@ -73,7 +73,6 @@ class Gibbs:
 
         # Store target and allow conditioning to reduce to a single density
         self.target = target() # Create a copy of target distribution (to avoid modifying the original)
-        self.target._allow_reduce = True
 
         # Parse samplers and split any keys that are tuple into separate keys
         self.samplers = {}

--- a/demos/dev/JointDistribution.py
+++ b/demos/dev/JointDistribution.py
@@ -94,26 +94,14 @@ Cd = joint(y=yh, x=xh, l=lh)
 Cl = joint(y=yh, x=xh, d=dh)
 
 # We can try inspecting one of these conditional distributions.
-# Notice how the equations and densities change to reflect the conditioning.
-# In particular how the equation reflects a likelihood+prior structure.
+# Notice how conditional distributions changed into a posterior distribution.
 print(Cd)
 
 # %%
 # Going into the internals of the joint distribution
 # --------------------------------------------------
 #
-# One of the major tricks we currently employ to make the joint distribution
-# work with our samplers is to allow reducing the joint distribution to a
-# single Density (Distribution, Likelihood or Posterior). This is because
-# our samplers are implemented to work with these.
-# 
-# The way this is achieved is by calling a private method as shown below,
-# when conditioning. The samplers can then directly use the resulting Density.
-
-Cd._reduce_to_single_density()
-
-# %%
-# Another "hack" is to have the joint distribution act as if it were a single
+# A useful "hack" is to have the joint distribution act as if it were a single
 # parameter density. This is achieved by calling the `._as_stacked()` method.
 # This returns a new "stacked" joint distribution that the samplers/solvers
 # can use as if it were any other Density.

--- a/demos/tutorials/JointDistribution.py
+++ b/demos/tutorials/JointDistribution.py
@@ -166,10 +166,13 @@ posterior_hier = joint_hier(y=y_obs)
 # Notice how the density for y becomes a likelihood
 print(posterior_hier)
 
+# In this case the posterior is still a joint distribution
+# over the parameters d, l, and x.
+
 # %%
 #
 # .. note::
 #
-#     The posterior distribution as shown above can be sampled via the sampler module.
-#     See e.g. the tutorial on sampling :doc:`Sampling tutorial <../_auto_tutorials/4-Samplers>`.
+#     The joint distribution as shown above can be sampled via the sampler module.
+#     See e.g. the tutorial on Gibbs sampling :doc:`Gibbs tutorial <../_auto_tutorials/Gibbs>`.
 #

--- a/tests/test_joint_distribution.py
+++ b/tests/test_joint_distribution.py
@@ -91,6 +91,7 @@ def test_joint_dist_logd(densities):
 @pytest.mark.parametrize("densities", [
     [
         cuqi.distribution.Gamma(1, 1e-4, name="x"),
+        cuqi.distribution.GaussianCov(0, lambda x:x, name="z"),
         cuqi.distribution.Normal(0, lambda x:x, name="y")
     ],
     [
@@ -160,9 +161,6 @@ def test_joint_dist_reduce():
     """ This tests the reduce hack for the joint distribution. """
 
     J, data = hierarchical_joint()   
-
-    # Allow reduce
-    J._allow_reduce = True
 
     # Check if we get the expected result when conditioning.
     assert isinstance(J(y=data), cuqi.distribution.JointDistribution)


### PR DESCRIPTION
Closes #64 

The edit in tests is because the Joint reduced to Posterior, which was not something that was aimed to test. 