### PR TITLE
RTO sampler with the Wang example

### DIFF
--- a/cuqi/sampler/_rto.py
+++ b/cuqi/sampler/_rto.py
@@ -1,9 +1,20 @@
 import scipy as sp
 import numpy as np
 import cuqi
-from cuqi.solver import CGLS
+from cuqi.solver import CGLS, LM, LS
 from cuqi.sampler import Sampler
 
+# try importing fast sparse libraries
+try:
+    import sparseqr 
+    spaqr = True
+except ImportError:
+    spaqr = False
+try:
+    from sksparse.cholmod import cholesky
+    chols = True
+except ImportError:
+    chols = False
 
 class Linear_RTO(Sampler):
     """
@@ -61,13 +72,13 @@ class Linear_RTO(Sampler):
                 raise TypeError("Model needs to be cuqi.model.LinearModel or matrix")
 
             # Likelihood
-            L = cuqi.distribution.Gaussian(model, sqrtprec=L_sqrtprec).to_likelihood(data)
+            L = cuqi.distribution.GaussianSqrtPrec(model, L_sqrtprec).to_likelihood(data)
 
             # Prior TODO: allow multiple priors stacked
             #if isinstance(P_mean, list) and isinstance(P_sqrtprec, list):
             #    P = cuqi.distribution.JointGaussianSqrtPrec(P_mean, P_sqrtprec)
             #else:
-            P = cuqi.distribution.Gaussian(P_mean, sqrtprec=P_sqrtprec)
+            P = cuqi.distribution.GaussianSqrtPrec(P_mean, P_sqrtprec)
 
             # Construct posterior
             target = cuqi.distribution.Posterior(L, P)
@@ -165,3 +176,272 @@ class Linear_RTO(Sampler):
 
     def _sample_adapt(self, N, Nb):
         return self._sample(N,Nb)
+
+#====================================================================
+#====================================================================
+#====================================================================
+class RTO(Sampler):
+    """
+    RTO (Randomize-Then-Optimize) sampler.
+
+    Samples posterior related to an inverse problem with Gaussian likelihood.
+    Other priors can be used after a suitable transformation to the standard Gaussian space.
+    Model can be nonlinear.
+
+    Parameters
+    ------------
+    target : `cuqi.distribution.Posterior` or 3-dimensional tuple.
+        If target is of type cuqi.distribution.Posterior, it represents the posterior distribution.
+        If target is a 3-dimensional tuple, it assumes the following structure:
+        (data, model, L_sqrtprec)
+        
+        Here:
+        data: is a m-dimensional numpy array containing the measured data.
+        model: is a m by n dimensional matrix or LinearModel representing the forward model.
+        L_sqrtprec: is the squareroot of the precision matrix of the Gaussian likelihood.
+
+    x0 : `np.ndarray` 
+        Initial point for the sampler. *Optional*.
+
+    maxit : int
+        Maximum number of iterations of the inner solver. *Optional*.
+
+    tol : float
+        Tolerance of the inner solver. *Optional*.
+
+    callback : callable, *Optional*
+        If set this function will be called after every sample.
+        The signature of the callback function is `callback(sample, sample_index)`,
+        where `sample` is the current sample and `sample_index` is the index of the sample.
+        An example is shown in demos/demo31_callback.py.
+        
+    """
+    def __init__(self, target, T, J_fun, mode='MAP', unadjusted=False, x0=None, maxit=100, tol=1e-4, **kwargs):
+
+        # Accept tuple of inputs and construct posterior
+        if isinstance(target, tuple) and len(target) == 3:
+            # Structure (data, model, L_sqrtprec, P_mean, P_sqrtprec)
+            data = target[0]
+            model = target[1]
+            L_sqrtprec = target[2]
+
+            # If numpy matrix convert to CUQI model
+            if isinstance(model, np.ndarray) and len(model.shape) == 2:
+                model = cuqi.model.LinearModel(model)
+
+            # Likelihood
+            L = cuqi.distribution.GaussianSqrtPrec(model, L_sqrtprec).to_likelihood(data)
+
+            # Prior: standard Gaussian
+            P = cuqi.distribution.GaussianCov(mean=np.zeros(self.n), cov=1)
+
+            # Construct posterior
+            target = cuqi.distribution.Posterior(L, P)
+
+        super().__init__(target, x0=x0, **kwargs)
+
+        # Check target type
+        if not isinstance(target, cuqi.distribution.Posterior):
+            raise ValueError(f"To initialize an object of type {self.__class__}, 'target' need to be of type 'cuqi.distribution.Posterior'.")       
+
+        if not hasattr(self.likelihood.distribution, "sqrtprec"):
+            raise TypeError("Distribution in Likelihood must contain a sqrtprec attribute")
+
+        # Modify initial guess        
+        if x0 is not None:
+            self.x0 = x0
+        else:
+            self.x0 = np.zeros(self.prior.dim)
+
+        # Other parameters
+        self.maxit = maxit
+        self.tol = tol
+        self.T = T
+        self.J_fun = J_fun
+        if hasattr(self.data, '__len__'):
+            self.m = len(self.data)
+        else:
+            self.m = 1
+        if hasattr(self.x0, '__len__'):
+            self.n = len(self.x0)
+        else:
+            self.n = 1
+        #
+        In = sp.sparse.eye(self.n, dtype=int)
+        lambd = self.likelihood.distribution.sqrtprec
+
+        if callable(self.model):
+            # model is a function
+            def M(u, e):
+                x = self.T(u)   # nonlinear transformation
+                r = np.append(np.dot(lambd, (self.model(x) - self.data)), u) - e # residual
+                # r = np.hstack([lambd*(self.model(x) - self.data), u]) - e
+                return r
+            def Jac(u):
+                dT_du = self.J_fun(u)
+                dF_dT = self.model.gradient(dT_du, self.T(u))
+                J = sp.sparse.vstack([np.dot(lambd, dF_dT), In])
+                return J
+        else:
+            raise TypeError("The model has to be callable")
+
+        # store
+        self.M = M
+        self.Jac = Jac
+
+        # find the MAP and matrix Q for RTO proposal
+        self.e0 = np.zeros(self.m+self.n)
+        u0 = np.ones(self.n)
+        if mode.lower() == 'map':
+            print('\nQ from the Jacobian at the MAP...')
+            utrg, _, _ = self._solve(lambda u: M(u, self.e0), u0, Jac, tol=1e-6, maxit=int(3e4), method='LS')
+            Jeval = Jac(utrg)
+        elif mode.lower() == 'prior':
+            print('\nQ equal identity...')
+            Jeval = sp.sparse.eye(self.m+self.n, dtype=int)
+        elif mode.lower() == 'prerun':
+            print('\nQ from the Jacobian at the mean of 5e2 unadjusted samples...')
+            N = int(5e2)
+            uMAP, _, _ = self._solve(lambda u: M(u, self.e0), u0, Jac, tol=1e-6, maxit=int(3e4), method='LS')
+            Jeval = Jac(uMAP)
+            self.Q, _ = self._Qfun(Jeval)
+            self.unadjusted = True
+            usamp = self.sample(N, 0)
+            utrg = np.mean(usamp.samples, axis=1)
+            Jeval = Jac(utrg)
+            print('Done !\n')
+        else:
+            raise TypeError("mode has to be: 'MAP', 'prior', or 'prerun'")
+        self.Q, _ = self._Qfun(Jeval)
+        self.unadjusted = unadjusted
+        # plt.figure(1)
+        # plt.plot(self.T(uMAP), 'b--')
+        # plt.plot(self.T(utrg), 'r--')
+        # plt.show()
+
+    @property
+    def prior(self):
+        return self.target.prior
+
+    @property
+    def likelihood(self):
+        return self.target.likelihood
+
+    @property
+    def model(self):
+        return self.target.model     
+
+    @property
+    def data(self):
+        return self.target.data
+
+    def _sample(self, N, Nb):
+        Ns = N+Nb   # number of simulations
+
+        # allocation
+        samples = np.empty((self.dim, Ns))
+        samples_prop = np.empty((self.dim, Ns))
+        logq_RTO_eval = np.empty(Ns)
+        acc = np.zeros(Ns, dtype=int)
+        ite = np.zeros(Ns, dtype=int)
+
+        # initial state    
+        samples[:, 0] = self.x0
+        logq_RTO_eval[0], _, _ = self._RTO_proposal(samples[:, 0], 'eval')
+        acc[0] = 1
+
+        # run MCMC
+        for s in range(Ns-1):
+            if self.unadjusted:
+                samples[:, s+1], acc[s+1], ite[s+1] = self._single_update_unadjusted(\
+                    samples[:, s])
+            else:
+                samples[:, s+1], samples_prop[:, s+1], logq_RTO_eval[s+1], acc[s+1], ite[s+1] = self._single_update(\
+                samples[:, s], logq_RTO_eval[s])
+            self._print_progress(s+2, Ns) #s+2 is the sample number, s+1 is index assuming x0 is the first sample
+            self._call_callback(samples[:, s+1], s+1)
+
+        # remove burn-in
+        samples = samples[:, Nb:]
+        samples_prop = samples_prop[:, Nb:]
+        logq_RTO_eval = logq_RTO_eval[Nb:]
+        accave = acc[Nb:].mean()   
+        print('\nAverage acceptance rate:', accave, '\n')
+        return samples, logq_RTO_eval, accave, samples_prop
+
+    def _single_update(self, theta_t, logq_RTO_t):
+        # propose state
+        theta_star, nres, it = self._RTO_proposal(theta_t, 'sample')   # sample from the proposal
+        logq_RTO_star, _, _ = self._RTO_proposal(theta_star, 'eval')
+
+        # ratio and acceptance probability
+        log_prop_ratio = logq_RTO_t - logq_RTO_star
+        log_alpha = min(0, log_prop_ratio)
+
+        # accept/reject
+        log_u = np.log(np.random.rand())
+        if (log_u < log_alpha) and (nres < 1e-8):
+            x_next = theta_star
+            logq_RTO_eval_next = logq_RTO_star
+            acc = 1
+        else:
+            x_next = theta_t
+            logq_RTO_eval_next = logq_RTO_t
+            acc = 0
+        # plt.figure(2)
+        # plt.plot(self.T(x_next))
+        # plt.pause(1)
+        return x_next, theta_star, logq_RTO_eval_next, acc, it
+    
+    def _single_update_unadjusted(self, theta_t):
+        # propose state
+        theta_star, _, it = self._RTO_proposal(theta_t, 'sample')   # sample from the proposal
+        # logq_RTO_star, _, _ = self._RTO_proposal(theta_star, 'eval')
+
+        return theta_star, 1, it
+
+    def _RTO_proposal(self, u_k, flag):
+        if (flag == 'eval'):
+            r = self.M(u_k, self.e0)
+            QtJ = self.Q.T @ self.Jac(u_k)
+            logdet = self._logdet(QtJ)
+            #
+            val = logdet + 0.5*(np.linalg.norm(r)**2 - np.linalg.norm(self.Q.T @ r)**2) # Eq. 6.30 John's
+            nres, it = [], []
+        elif (flag == 'sample'):
+            e = np.random.randn(self.m+self.n)
+            fun_k = lambda u: self.Q.T @ self.M(u, e)
+            Jac_k = lambda u: self.Q.T @ self.Jac(u)
+            val, nres, it = self._solve(fun_k, u_k, Jac_k, self.tol, self.maxit)            
+        return val, nres, it
+
+    def _solve(self, fun, u, Jac, tol, maxit, method='LS'):
+        if method == 'LS':
+            opt, info = LS(fun, u, Jac, tol=tol, maxit=maxit).solve()
+        elif method == 'LM':
+            opt, info = LM(fun, u, Jac, tol=tol, maxit=maxit).solve()
+        val, Qtr, it = opt, info['func'], info['nfev']
+        nres = np.linalg.norm(Qtr)**2
+        return val, nres, it
+    
+    def _Qfun(self, J):
+        if spaqr:
+            Q, R, _, _ = sparseqr.qr(J, economy=True)
+        else:
+            Q, R = np.linalg.qr(J.todense(), mode='reduced')
+            Q = sp.sparse.csc_matrix(Q)
+        return Q, R
+
+    def _logdet(self, QtJ):
+        if spaqr: 
+            _, R, = self._Qfun(QtJ)     
+            logdet = np.sum(np.log(np.abs(R.diagonal())))
+        elif chols:
+            chol = cholesky(QtJ.T @ QtJ, ordering_method='natural')
+            logdet = 0.5*chol.logdet()
+        else:
+            logdet = np.sum(np.log(np.diag(np.linalg.cholesky((QtJ.T @ QtJ).todense()))))
+        return logdet
+
+    def _sample_adapt(self, N, Nb):
+        return self._sample(N, Nb)

--- a/cuqi/sampler/_sampler.py
+++ b/cuqi/sampler/_sampler.py
@@ -101,24 +101,26 @@ class Sampler(ABC):
         loglike_eval = None
         acc_rate = None
         if isinstance(result,tuple):
-            #Unpack samples+loglike+acc_rate
+            #Unpack samples+loglike+acc_rate+proposedsamples
             s = result[0]
             if len(result)>1: loglike_eval = result[1]
             if len(result)>2: acc_rate = result[2]
-            if len(result)>3: raise TypeError("Expected tuple of at most 3 elements from sampling method.")
+            if len(result)>3: sp = result[3]
+            if len(result)>4: raise TypeError("Expected tuple of at most 4 elements from sampling method.")
         else:
             s = result
-                
+
         #Store samples in cuqi samples object if more than 1 sample
         if N==1:
             if len(s) == 1 and isinstance(s,np.ndarray): #Extract single value from numpy array
                 s = s.ravel()[0]
             else:
                 s = s.flatten()
-        else:
-            s = Samples(s, self.geometry)#, geometry = self.geometry)
-            s.loglike_eval = loglike_eval
-            s.acc_rate = acc_rate
+        s = Samples(s, self.geometry)#, geometry = self.geometry)
+        s.loglike_eval = loglike_eval
+        s.acc_rate = acc_rate        
+        if len(result)>3:
+            s.samples_prop = sp
         return s
 
     @abstractmethod

--- a/demos/demo35_RTO_Wang.py
+++ b/demos/demo35_RTO_Wang.py
@@ -1,0 +1,106 @@
+# =================================================================
+# Created by:
+# Felipe Uribe @ DTU
+# =================================================================
+# Version 2022
+# =================================================================
+import sys
+import numpy as np
+import time
+sys.path.append("..") 
+import numpy as np
+#
+import cuqi
+import matplotlib.pyplot as plt
+
+# =================================================================
+tp = cuqi.testproblem.WangCubic()
+n = tp.model.domain_dim
+forward = tp.model.forward
+y_data = tp.data
+
+# transformation
+mu_pr = tp.prior.mean
+def T(u):
+    x = mu_pr + u
+    return x
+
+# Jacobian of the transformation
+In = np.identity(n)
+def J_fun(u):
+    return In
+
+# =================================================================
+# sample
+# ================================================================
+np.random.seed(1)
+Ns = int(3e3)
+Nb = int(0.1*Ns)
+u0 = np.random.randn(n)
+
+# set sampler
+smp = 'NUTS'
+if smp == 'RTO':
+    MCMC = cuqi.sampler._rto.RTO(tp.posterior, T, J_fun, mode='MAP', unadjusted=False, x0=u0)
+elif smp == 'NUTS':
+    MCMC = cuqi.sampler.NUTS(tp.posterior, u0, max_depth=12)
+
+# sample
+tic = time.time()
+sol = MCMC.sample(Ns, Nb)
+toc = time.time()-tic
+print('\nElapsed time\n:', toc) 
+
+if smp == 'RTO':
+    uchain = sol.samples.T
+    uchain_prop = sol.samples_prop.T
+    # transform back to the original space
+    x_chain = T(uchain)
+    x_chain_prop = T(uchain_prop)
+elif smp == 'NUTS':
+    x_chain = sol.samples.T
+
+mu = np.mean(x_chain, axis=0)
+print(mu) 
+
+# ================================================================
+fig, axes = plt.subplots(2, 1, figsize=(12, 4))
+ax1, ax2 = axes.flatten()
+ax1.plot(x_chain[:, 0], 'k-', linewidth=1)
+ax1.set_xlim(0, Ns)
+ax1.set_ylabel(r'$x_1$')
+#
+ax2.plot(x_chain[:, 1], 'k-', linewidth=1)
+ax2.set_xlim(0, Ns)
+ax2.set_ylabel(r'$x_2$')
+#
+if smp == 'RTO':
+    ax1.plot(x_chain_prop[:, 0], 'r--', linewidth=1, alpha=0.5)
+    ax2.plot(x_chain_prop[:, 1], 'r--', linewidth=1, alpha=0.5)
+plt.tight_layout()
+
+#################
+n1 = 100
+xx = np.linspace(-2, 2, n1)
+X, Y = np.meshgrid(xx, xx)
+grid = np.vstack([X.flatten(), Y.flatten()]).T
+n = grid.shape[0]
+#
+pi_pos_eval, pi_pr_eval = np.empty(n), np.empty(n)
+for i in range(n):
+    pi_pr_eval[i] = tp.prior.pdf(grid[i, :])
+    pi_pos_eval[i] = tp.posterior.pdf(grid[i, :])
+
+fig = plt.figure()
+cs1 = plt.contour(X, Y, pi_pr_eval.reshape(n1, n1), 15, cmap='Blues')
+cs2 = plt.contour(X, Y, pi_pos_eval.reshape(n1, n1), 20, cmap='Reds')
+plt.plot(x_chain[:, 0], x_chain[:, 1], 'k.', markersize=1.5, label='accepted')
+if smp == 'RTO':
+    plt.plot(x_chain_prop[:, 0], x_chain_prop[:, 1], 'ro', fillstyle='none', markersize=3, label='proposed')
+plt.legend()
+plt.xlim(-2, 2)
+plt.ylim(-1, 2)
+fig.gca().set_aspect("equal")
+plt.tight_layout()
+# plt.savefig('sol_mean.pdf', format='pdf', dpi=150, bbox_inches='tight')
+plt.show()


### PR DESCRIPTION
The example is ready. However there is an issue with the gradient in the Wang model. So far we take gradients of PDFs with respect to model functions. But for RTO we need the gradient with respect to a transformation into the standard Gaussian space. The current gradient implementation does not includes this setting, since the 'direction' concept is different now.

As a result, the demo_Wang example is not running. However, I tested it, and it runs using the correct gradient.

Recall this is the setup for non-Gaussian priors:
![image](https://github.com/CUQI-DTU/CUQIpy/assets/25250158/f9d1bb50-cfcf-42ed-a29c-a99412166cfd)

Moreover, this is the idea of the adaptive RTO for Q (ref to Wang's: http://dspace.mit.edu/handle/1721.1/98815):
![image](https://github.com/CUQI-DTU/CUQIpy/assets/25250158/2abb64da-830a-4e30-9964-13e8233f2763)
