### PR TITLE
Sprint15 add multiple likelihood posterior

### DIFF
--- a/cuqi/distribution/__init__.py
+++ b/cuqi/distribution/__init__.py
@@ -13,4 +13,4 @@ from ._normal import Normal
 from ._posterior import Posterior
 from ._uniform import Uniform
 from ._custom import UserDefinedDistribution, DistributionGallery
-from ._joint_distribution import JointDistribution, _StackedJointDistribution
+from ._joint_distribution import JointDistribution, _StackedJointDistribution, MultipleLikelihoodPosterior

--- a/cuqi/distribution/__init__.py
+++ b/cuqi/distribution/__init__.py
@@ -13,4 +13,4 @@ from ._normal import Normal
 from ._posterior import Posterior
 from ._uniform import Uniform
 from ._custom import UserDefinedDistribution, DistributionGallery
-from ._joint_distribution import JointDistribution, _StackedJointDistribution, SingleVariablePosterior
+from ._joint_distribution import JointDistribution, _StackedJointDistribution, MultipleLikelihoodPosterior

--- a/cuqi/distribution/__init__.py
+++ b/cuqi/distribution/__init__.py
@@ -13,4 +13,4 @@ from ._normal import Normal
 from ._posterior import Posterior
 from ._uniform import Uniform
 from ._custom import UserDefinedDistribution, DistributionGallery
-from ._joint_distribution import JointDistribution, _StackedJointDistribution, MultipleLikelihoodPosterior
+from ._joint_distribution import JointDistribution, _StackedJointDistribution, SingleVariablePosterior

--- a/cuqi/distribution/_joint_distribution.py
+++ b/cuqi/distribution/_joint_distribution.py
@@ -305,6 +305,22 @@ class _StackedJointDistribution(JointDistribution, Distribution):
 
 
 class MultipleLikelihoodPosterior(JointDistribution, Distribution):
+    """ A posterior distribution with multiple likelihoods but a single prior.
+
+    Parameters
+    ----------
+    densities : :class:`Distribution` or :class:`~cuqi.likelihood.Likelihood`
+        The densities that make up the Posterior. Must only include
+        a single distribution and at least two Likelihoods.
+
+    Notes
+    -----    
+    This acts like a regular distribution with a single parameter vector. Behind-the-scenes
+    it is a joint distribution with multiple likelihoods and a single prior. This is mostly
+    intended to be used by samplers that are not able to handle joint distributions. 
+    See :class:`JointDistribution` for more details on the joint distribution.   
+    
+    """
 
     def __init__(self, *densities: Density):
         super().__init__(*densities)
@@ -317,28 +333,34 @@ class MultipleLikelihoodPosterior(JointDistribution, Distribution):
 
     @property
     def geometry(self):
+        """ The geometry of the distribution. """
         return self._distributions[0].geometry
 
     @property
     def dim(self):
+        """ Return the dimension of the distribution. """
         return self._distributions[0].dim
 
     @property
     def prior(self):
+        """ Return the prior distribution that makes up the posterior. """
         return self._distributions[0]
 
     @property
     def models(self):
+        """ Return the forward models that make up the posterior. """
         return [likelihood.model for likelihood in self._likelihoods]
 
     @property
     def likelihoods(self):
+        """ Return the likelihoods that make up the posterior. """
         return self._likelihoods
 
     def logpdf(self, *args, **kwargs):
         return self.logd(*args, **kwargs)
 
     def gradient(self, *args, **kwargs):
+        """ Return the gradient of the un-normalized log density function. """
         grad = self.prior.gradient(*args, **kwargs)
         for likelihood in self.likelihoods:
             grad += likelihood.gradient(*args, **kwargs)

--- a/cuqi/distribution/_joint_distribution.py
+++ b/cuqi/distribution/_joint_distribution.py
@@ -368,7 +368,7 @@ class MultipleLikelihoodPosterior(JointDistribution, Distribution):
         if len(self._densities) < 3:
             raise ValueError(f"{self.__class__.__name__} requires at least three densities. For a single likelihood and prior use Posterior instead.")
         
-        if len(self.likelihoods) == 0 or len(self.prior) == 0:
+        if len(self.likelihoods) == 0:
             raise ValueError(f"{self.__class__.__name__} must have a likelihood and prior.")
 
         # Check that there is only a single parameter

--- a/cuqi/distribution/_joint_distribution.py
+++ b/cuqi/distribution/_joint_distribution.py
@@ -303,6 +303,7 @@ class _StackedJointDistribution(JointDistribution, Distribution):
     def __repr__(self):
         return "_Stacked"+super().__repr__()
 
+
 class MultipleLikelihoodPosterior(JointDistribution, Distribution):
 
     def __init__(self, *densities: Density):
@@ -322,8 +323,26 @@ class MultipleLikelihoodPosterior(JointDistribution, Distribution):
     def dim(self):
         return self._distributions[0].dim
 
+    @property
+    def prior(self):
+        return self._distributions[0]
+
+    @property
+    def models(self):
+        return [likelihood.model for likelihood in self._likelihoods]
+
+    @property
+    def likelihoods(self):
+        return self._likelihoods
+
     def logpdf(self, *args, **kwargs):
         return self.logd(*args, **kwargs)
+
+    def gradient(self, *args, **kwargs):
+        grad = self.prior.gradient(*args, **kwargs)
+        for likelihood in self.likelihoods:
+            grad += likelihood.gradient(*args, **kwargs)
+        return grad
 
     def _sample(self, Ns=1):
         raise TypeError(f"{self.__class__.__name__} does not support sampling.")

--- a/cuqi/distribution/_joint_distribution.py
+++ b/cuqi/distribution/_joint_distribution.py
@@ -294,7 +294,36 @@ class _StackedJointDistribution(JointDistribution, Distribution):
         return self.logd(stacked_input)
     
     def _sample(self, Ns=1):
-        raise TypeError("StackedJointDistribution does not support sampling.")
+        raise TypeError(f"{self.__class__.__name__} does not support sampling.")
 
     def __repr__(self):
         return "_Stacked"+super().__repr__()
+
+class MultipleLikelihoodPosterior(JointDistribution, Distribution):
+
+    def __init__(self, *densities: Density):
+        super().__init__(*densities)
+
+        # Check that there is only a single distribution and multiple likelihoods
+        if len(self._distributions) != 1:
+            raise ValueError(f"MultipleLikelihoodPosterior requires exactly one distribution.")
+        if len(self._likelihoods) < 2:
+            raise ValueError(f"MultipleLikelihoodPosterior requires at least two likelihoods.")
+
+    @property
+    def geometry(self):
+        return self._distributions[0].geometry
+
+    @property
+    def dim(self):
+        return self._distributions[0].dim
+
+    def logpdf(self, *args, **kwargs):
+        return self.logd(*args, **kwargs)
+
+    def _sample(self, Ns=1):
+        raise TypeError(f"{self.__class__.__name__} does not support sampling.")
+
+    def __repr__(self):
+        # Remove first line of super repr and add "MultipleLikelihoodPosterior( to the start
+        return "MultipleLikelihoodPosterior(\n" + "\n".join(super().__repr__().split("\n")[1:])

--- a/cuqi/distribution/_joint_distribution.py
+++ b/cuqi/distribution/_joint_distribution.py
@@ -189,8 +189,12 @@ class JointDistribution:
         n_likelihood = len(self._likelihoods)
 
         # Cant reduce if there are multiple distributions or likelihoods
-        if n_dist > 1 or n_likelihood > 1:
+        if n_dist > 1:
             return self
+
+        # If exactly one distribution and multiple likelihoods reduce
+        if n_dist == 1 and n_likelihood > 1:
+            return MultipleLikelihoodPosterior(*self._densities)
         
         # If exactly one distribution and one likelihood its a Posterior
         if n_dist == 1 and n_likelihood == 1:

--- a/demos/howtos/Defining_Posterior.py
+++ b/demos/howtos/Defining_Posterior.py
@@ -176,3 +176,5 @@ print(posterior3)
 # is then as simple as
 
 posterior3.logd(q=1, l=1, s=1, x=np.ones(A.domain_dim))
+
+# %%

--- a/demos/howtos/posterior.py
+++ b/demos/howtos/posterior.py
@@ -1,0 +1,109 @@
+"""
+How to define a Posterior distribution
+======================================
+
+The recommended way to define a posterior distribution is to use the
+:class:`cuqi.distribution.JointDistribution` class to define the joint
+distribution of the parameters and the data and then condition on observed
+data to obtain the posterior distribution as shown in the examples below.
+"""
+
+# %%
+# Imports
+import cuqi
+import numpy as np
+
+# %%
+# A simple Bayesian inverse problem
+# --------------------------------
+#
+# .. math::
+#    \mathbf{y} = \mathbf{A}\mathbf{x}
+#
+# See :class:~`cuqi.testproblem.Deconvolution1D` for more details.
+#
+# .. math::
+#    \mathbf{x} \sim \mathcal{N}(\mathbf{0}, 0.2\mathbf{I})\\
+#    \mathbf{y} \sim \mathcal{N}(\mathbf{A}\mathbf{x}, 0.1\mathbf{I})
+#
+
+# Forward model and data
+A, y_obs, _ = cuqi.testproblem.Deconvolution1D.get_components()
+
+# Bayesian model
+x = cuqi.distribution.Gaussian(np.zeros(A.domain_dim), 0.1)  # x ~ N(0,1)
+y = cuqi.distribution.Gaussian(A(x), 0.05**2)                # y ~ N(A(x), 0.05^2)
+
+# %% Joint distribution
+joint = cuqi.distribution.JointDistribution(x, y)              # p(x,y)
+print(joint)
+
+# %% Posterior distribution
+posterior = joint(y=y_obs)                                     # p(x|y=y_obs)
+print(posterior)
+
+
+# %%
+# One parameter, two forward models
+# ---------------------------------
+#
+# .. math::
+#    \mathbf{y} = \mathbf{A}\mathbf{x}\\
+#    \mathbf{d} = \mathbf{B}\mathbf{x}\\
+#
+# .. math::
+#    \mathbf{x} \sim \mathcal{N}(\mathbf{0}, 0.2\mathbf{I})\\
+#    \mathbf{y} \sim \mathcal{N}(\mathbf{A}\mathbf{x}, 0.1\mathbf{I})\\
+#    \mathbf{d} \sim \mathcal{N}(\mathbf{B}\mathbf{x}, 0.3\mathbf{I})
+
+# Two forward models, same x generated the data
+A, y_obs, _ = cuqi.testproblem.Deconvolution1D.get_components()
+B, d_obs, _ = cuqi.testproblem.Deconvolution1D.get_components(kernel="sinc", noise_std=0.01)
+
+# Define distributions
+x = cuqi.distribution.Gaussian(np.zeros(A.domain_dim), 0.1)  # x ~ N(0,1)
+y = cuqi.distribution.Gaussian(A(x), 0.05**2)                # y ~ N(A(x), 0.05^2)
+d = cuqi.distribution.Gaussian(B(x), 0.01**2)                # d ~ N(B(x), 0.5^2)
+
+# %% Joint distribution
+joint2 = cuqi.distribution.JointDistribution(x, y, d)          # p(x,y,d)
+print(joint2)
+
+# %% Posterior distribution
+posterior2 = joint2(y=y_obs, d=d_obs)                           # p(x|y=y_obs, d=d_obs)
+print(posterior2)
+
+# %%
+# Multiple parameters, multiple forward models
+# --------------------------------------------
+#
+# .. math::
+#    \mathbf{y} = \mathbf{A}\mathbf{x}\\
+#    \mathbf{d} = \mathbf{B}\mathbf{x}\\
+#
+# .. math::
+#    \mathbf{l} \sim \mathrm{Gamma}(1, 1)\\
+#    \mathbf{s} \sim \mathrm{Gamma}(0, 10^{-2})\\
+#    \mathbf{x} \sim \mathcal{N}(\mathbf{0}, l^{-1}\mathbf{I})\\
+#    \mathbf{y} \sim \mathcal{N}(\mathbf{A}\mathbf{x}, s^{-1}\mathbf{I})\\
+#    \mathbf{d} \sim \mathcal{N}(\mathbf{B}\mathbf{x}, 0.3\mathbf{I})
+
+# Two forward models, same x generated the data
+A, y_obs, _ = cuqi.testproblem.Deconvolution1D.get_components()
+B, d_obs, _ = cuqi.testproblem.Deconvolution1D.get_components(kernel="sinc", noise_std=0.01)
+
+# Define distributions
+l = cuqi.distribution.Gamma(1, 1)                                      # l ~ Gamma(1,1)
+s = cuqi.distribution.Gamma(0, 1e-2)                                   # s ~ Gamma(0,1e-2)
+x = cuqi.distribution.Gaussian(np.zeros(A.domain_dim), lambda l: 1/l)  # x ~ N(0,1/l)
+y = cuqi.distribution.Gaussian(A(x), lambda s: 1/s)                    # y ~ N(A(x), 1/s)
+d = cuqi.distribution.Gaussian(B(x), 0.01**2)                          # d ~ N(B(x), 0.5^2)
+
+# %% Joint distribution
+joint3 = cuqi.distribution.JointDistribution(l, s, x, y, d)    # p(l,s,x,y,d)
+print(joint3)
+
+# %% Posterior distribution
+posterior3 = joint3(y=y_obs, d=d_obs)                         # p(l,s,x|y=y_obs, d=d_obs)
+print(posterior3)
+# %%

--- a/demos/howtos/posterior.py
+++ b/demos/howtos/posterior.py
@@ -98,7 +98,7 @@ joint2 = cuqi.distribution.JointDistribution(x, y, d)
 print(joint2)
 
 # %%
-# The posterior :math:`p(\mathbf{x}|\mathbf{y}=\mathbf{y}^\mathrm{obs},d=\mathbf{d}^\mathrm{obs})`
+# The posterior :math:`p(\mathbf{x}|\mathbf{y}=\mathbf{y}^\mathrm{obs},\mathbf{d}=\mathbf{d}^\mathrm{obs})`
 # is obtained by conditioning on the observed data as follows.
 
 posterior2 = joint2(y=y_obs, d=d_obs)

--- a/demos/howtos/posterior.py
+++ b/demos/howtos/posterior.py
@@ -2,108 +2,177 @@
 How to define a Posterior distribution
 ======================================
 
-The recommended way to define a posterior distribution is to use the
-:class:`cuqi.distribution.JointDistribution` class to define the joint
+The recommended way to define a posterior distribution in CUQIpy is to use the
+:class:`~cuqi.distribution.JointDistribution` class to define the joint
 distribution of the parameters and the data and then condition on observed
 data to obtain the posterior distribution as shown in the examples below.
 """
 
 # %%
-# Imports
 import cuqi
 import numpy as np
 
 # %%
 # A simple Bayesian inverse problem
-# --------------------------------
+# ---------------------------------
+# 
+# Consider a deconvolution inverse problem given by
 #
 # .. math::
-#    \mathbf{y} = \mathbf{A}\mathbf{x}
+#    \mathbf{y} = \mathbf{A}\mathbf{x}.
 #
-# See :class:~`cuqi.testproblem.Deconvolution1D` for more details.
-#
-# .. math::
-#    \mathbf{x} \sim \mathcal{N}(\mathbf{0}, 0.2\mathbf{I})\\
-#    \mathbf{y} \sim \mathcal{N}(\mathbf{A}\mathbf{x}, 0.1\mathbf{I})
-#
+# See :class:`~cuqi.testproblem.Deconvolution1D` for more details.
 
-# Forward model and data
 A, y_obs, _ = cuqi.testproblem.Deconvolution1D.get_components()
-
-# Bayesian model
-x = cuqi.distribution.Gaussian(np.zeros(A.domain_dim), 0.1)  # x ~ N(0,1)
-y = cuqi.distribution.Gaussian(A(x), 0.05**2)                # y ~ N(A(x), 0.05^2)
-
-# %% Joint distribution
-joint = cuqi.distribution.JointDistribution(x, y)              # p(x,y)
-print(joint)
-
-# %% Posterior distribution
-posterior = joint(y=y_obs)                                     # p(x|y=y_obs)
-print(posterior)
-
 
 # %%
-# One parameter, two forward models
+# Then consider the following Bayesian model
+#
+# .. math::
+#    \begin{align*}
+#    \mathbf{x} &\sim \mathcal{N}(\mathbf{0}, 0.1\,\mathbf{I})\\
+#    \mathbf{y} &\sim \mathcal{N}(\mathbf{A}\mathbf{x}, 0.05^2\,\mathbf{I})
+#    \end{align*}
+#
+# which can be written in CUQIpy as
+
+x = cuqi.distribution.Gaussian(np.zeros(A.domain_dim), 0.1)
+y = cuqi.distribution.Gaussian(A(x), 0.05**2)
+
+# %%
+# The joint distribution :math:`p(\mathbf{x}, \mathbf{y})` is then obtained by
+
+joint = cuqi.distribution.JointDistribution(x, y)
+print(joint)
+
+# %% 
+# The posterior :math:`p(\mathbf{x}|\mathbf{y}=\mathbf{y}^\mathrm{obs})`
+# is obtained by conditioning on the observed data as follows.
+
+posterior = joint(y=y_obs)
+print(posterior)
+
+# %%
+# Evaluating the posterior log density is then as simple as
+
+posterior.logd(np.ones(A.domain_dim))
+
+# %%
+# Posterior with two forward models
 # ---------------------------------
 #
-# .. math::
-#    \mathbf{y} = \mathbf{A}\mathbf{x}\\
-#    \mathbf{d} = \mathbf{B}\mathbf{x}\\
+# Suppose we had two forward models :math:`\mathbf{A}` and :math:`\mathbf{B}`:
 #
 # .. math::
-#    \mathbf{x} \sim \mathcal{N}(\mathbf{0}, 0.2\mathbf{I})\\
-#    \mathbf{y} \sim \mathcal{N}(\mathbf{A}\mathbf{x}, 0.1\mathbf{I})\\
-#    \mathbf{d} \sim \mathcal{N}(\mathbf{B}\mathbf{x}, 0.3\mathbf{I})
+#    \begin{align*}
+#    \mathbf{y} &= \mathbf{A}\mathbf{x}\\
+#    \mathbf{d} &= \mathbf{B}\mathbf{x}\\
+#    \end{align*}
 
-# Two forward models, same x generated the data
+# Both observations come from the same unknown x
 A, y_obs, _ = cuqi.testproblem.Deconvolution1D.get_components()
-B, d_obs, _ = cuqi.testproblem.Deconvolution1D.get_components(kernel="sinc", noise_std=0.01)
+B, d_obs, _ = cuqi.testproblem.Deconvolution1D.get_components(
+    kernel="sinc",
+    noise_std=0.01
+)
 
-# Define distributions
-x = cuqi.distribution.Gaussian(np.zeros(A.domain_dim), 0.1)  # x ~ N(0,1)
-y = cuqi.distribution.Gaussian(A(x), 0.05**2)                # y ~ N(A(x), 0.05^2)
-d = cuqi.distribution.Gaussian(B(x), 0.01**2)                # d ~ N(B(x), 0.5^2)
+# %%
+# Then consider the following Bayesian model
+#
+# .. math::
+#    \begin{align*}
+#    \mathbf{x} &\sim \mathcal{N}(\mathbf{0}, 0.1\,\mathbf{I})\\
+#    \mathbf{y} &\sim \mathcal{N}(\mathbf{A}\mathbf{x}, 0.05^2\mathbf{I})\\
+#    \mathbf{d} &\sim \mathcal{N}(\mathbf{B}\mathbf{x}, 0.01^2\mathbf{I})
+#    \end{align*}
 
-# %% Joint distribution
-joint2 = cuqi.distribution.JointDistribution(x, y, d)          # p(x,y,d)
+x = cuqi.distribution.Gaussian(np.zeros(A.domain_dim), 0.1)
+y = cuqi.distribution.Gaussian(A(x), 0.05**2)
+d = cuqi.distribution.Gaussian(B(x), 0.01**2)
+
+# %%
+# The joint distribution :math:`p(\mathbf{x}, \mathbf{y}, \mathbf{d})` is then
+# obtained by
+
+joint2 = cuqi.distribution.JointDistribution(x, y, d)
 print(joint2)
 
-# %% Posterior distribution
-posterior2 = joint2(y=y_obs, d=d_obs)                           # p(x|y=y_obs, d=d_obs)
+# %%
+# The posterior :math:`p(\mathbf{x}|\mathbf{y}=\mathbf{y}^\mathrm{obs},d=\mathbf{d}^\mathrm{obs})`
+# is obtained by conditioning on the observed data as follows.
+
+posterior2 = joint2(y=y_obs, d=d_obs)
 print(posterior2)
 
 # %%
-# Multiple parameters, multiple forward models
-# --------------------------------------------
-#
-# .. math::
-#    \mathbf{y} = \mathbf{A}\mathbf{x}\\
-#    \mathbf{d} = \mathbf{B}\mathbf{x}\\
-#
-# .. math::
-#    \mathbf{l} \sim \mathrm{Gamma}(1, 1)\\
-#    \mathbf{s} \sim \mathrm{Gamma}(0, 10^{-2})\\
-#    \mathbf{x} \sim \mathcal{N}(\mathbf{0}, l^{-1}\mathbf{I})\\
-#    \mathbf{y} \sim \mathcal{N}(\mathbf{A}\mathbf{x}, s^{-1}\mathbf{I})\\
-#    \mathbf{d} \sim \mathcal{N}(\mathbf{B}\mathbf{x}, 0.3\mathbf{I})
+# Evaluating the posterior log density is then as simple as
 
-# Two forward models, same x generated the data
+posterior2.logd(np.ones(A.domain_dim))
+
+# %%
+# Arbitrarily complex posterior distributions
+# -------------------------------------------
+#
+# The :class:`~cuqi.distribution.JointDistribution` class can be used to
+# construct arbitrarily complex posterior distributions. For example suppose
+# we have the following 3 forward models
+#
+# .. math::
+#    \begin{align*}
+#    \mathbf{y} &= \mathbf{A}\mathbf{x}\\
+#    \mathbf{d} &= \mathbf{B}\mathbf{x}\\
+#    \mathbf{b} &= C(\mathbf{x})
+#    \end{align*}
+#
+# where :math:`C` is a nonlinear function.
+
+# Same x for all 3 observations
 A, y_obs, _ = cuqi.testproblem.Deconvolution1D.get_components()
-B, d_obs, _ = cuqi.testproblem.Deconvolution1D.get_components(kernel="sinc", noise_std=0.01)
+B, d_obs, _ = cuqi.testproblem.Deconvolution1D.get_components(
+    kernel="sinc",
+    noise_std=0.01
+)
+C = cuqi.model.Model(lambda x: np.linalg.norm(x)**2, 1, A.domain_dim)
+b_obs = 16
 
-# Define distributions
-l = cuqi.distribution.Gamma(1, 1)                                      # l ~ Gamma(1,1)
-s = cuqi.distribution.Gamma(0, 1e-2)                                   # s ~ Gamma(0,1e-2)
-x = cuqi.distribution.Gaussian(np.zeros(A.domain_dim), lambda l: 1/l)  # x ~ N(0,1/l)
-y = cuqi.distribution.Gaussian(A(x), lambda s: 1/s)                    # y ~ N(A(x), 1/s)
-d = cuqi.distribution.Gaussian(B(x), 0.01**2)                          # d ~ N(B(x), 0.5^2)
+# %%
+# Then consider the following Bayesian model
+#
+# .. math::
+#    \begin{align*}
+#    q          &\sim \mathcal{U}(0.1, 10)\\
+#    l          &\sim \mathrm{Gamma}(1, 1)\\
+#    s          &\sim \mathrm{Gamma}(1, 10^{-2})\\
+#    \mathbf{x} &\sim \mathcal{N}(\mathbf{0}, l^{-1}\mathbf{I})\\
+#    \mathbf{y} &\sim \mathcal{N}(\mathbf{A}\mathbf{x}, s^{-1}\mathbf{I})\\
+#    \mathbf{d} &\sim \mathcal{N}(\mathbf{B}\mathbf{x}, 0.01\mathbf{I})\\
+#    \mathbf{b} &\sim \mathcal{L}(\mathbf{C}(\mathbf{x}), q)
+#    \end{align*}
 
-# %% Joint distribution
-joint3 = cuqi.distribution.JointDistribution(l, s, x, y, d)    # p(l,s,x,y,d)
+q = cuqi.distribution.Uniform(0.1, 10)
+l = cuqi.distribution.Gamma(1, 1)
+s = cuqi.distribution.Gamma(1, 1e-2)
+x = cuqi.distribution.Gaussian(np.zeros(A.domain_dim), lambda l: 1/l)
+y = cuqi.distribution.Gaussian(A(x), lambda s: 1/s)
+d = cuqi.distribution.Gaussian(B(x), 0.01**2)
+b = cuqi.distribution.Laplace(C(x), lambda q: q)
+
+# %%
+# The joint distribution :math:`p(q, l, s, \mathbf{x}, \mathbf{y}, \mathbf{d}, \mathbf{b})`
+# is then obtained by
+
+joint3 = cuqi.distribution.JointDistribution(q, l, s, x, y, d, b)
 print(joint3)
 
-# %% Posterior distribution
-posterior3 = joint3(y=y_obs, d=d_obs)                         # p(l,s,x|y=y_obs, d=d_obs)
-print(posterior3)
 # %%
+# The posterior :math:`p(q, l, s, \mathbf{x}|\mathbf{y}=\mathbf{y}^\mathrm{obs},\mathbf{d}=\mathbf{d}^\mathrm{obs},\mathbf{b}=\mathbf{b}^\mathrm{obs})`
+# is obtained by conditioning on the observed data as follows.
+
+posterior3 = joint3(y=y_obs, d=d_obs, b=b_obs)
+print(posterior3)
+
+# %%
+# Evaluating the posterior log density jointly over p, l, s, and :math:`\mathbf{x}`
+# is then as simple as
+
+posterior3.logd(q=1, l=1, s=1, x=np.ones(A.domain_dim))

--- a/demos/tutorials/multiple_likelihoods.py
+++ b/demos/tutorials/multiple_likelihoods.py
@@ -247,7 +247,7 @@ z_joint = cuqi.distribution.JointDistribution(theta,y1,y2)(y1=data1, y2=data2)
 print(z_joint)
 
 # %%
-# We see that in this case we obtain a :class:`MultipleLikelihoodPosterior` 
+# We see that in this case we obtain a :class:`SingleVariablePosterior` 
 # object, which represents the posterior distribution of the parameters `theta`
 # given the data `y1` and `y2`. The posterior distribution in this case is 
 # proportional to the product of the two likelihoods and the prior.

--- a/demos/tutorials/multiple_likelihoods.py
+++ b/demos/tutorials/multiple_likelihoods.py
@@ -239,16 +239,15 @@ samples.compute_ess()
 # Create the posterior 
 # ~~~~~~~~~~~~~~~~~~~~~
 
-z_joint = cuqi.distribution.JointDistribution(theta,y1,y2)(y1=data1, y2=data2)._as_stacked() 
-# Note: _as_stacked() is needed to stack the random variables but it is a
-# temporary hack that will be not needed in the future.
+z_joint = cuqi.distribution.JointDistribution(theta,y1,y2)(y1=data1, y2=data2)
+
 
 # %%
 # We print the joint distribution `z_joint`:
 print(z_joint)
 
 # %%
-# We see that in this case we obtain a :class:`_StackedJointDistribution` 
+# We see that in this case we obtain a :class:`MultipleLikelihoodPosterior` 
 # object, which represents the posterior distribution of the parameters `theta`
 # given the data `y1` and `y2`. The posterior distribution in this case is 
 # proportional to the product of the two likelihoods and the prior.
@@ -260,11 +259,6 @@ print(z_joint)
 # Sample from the posterior
 sampler = cuqi.sampler.MetropolisHastings(z_joint)
 samples = sampler.sample_adapt(8000)
-
-# Set the samples geometry
-# Note: this step is will be not needed in the future as samples geometry will
-# be automatically determined.
-samples.geometry=theta.geometry 
 
 # Plot the credible interval and compute the ESS
 samples.burnthin(1000).plot_ci(95, exact=problemInfo1.exactSolution)

--- a/demos/tutorials/multiple_likelihoods.py
+++ b/demos/tutorials/multiple_likelihoods.py
@@ -247,7 +247,7 @@ z_joint = cuqi.distribution.JointDistribution(theta,y1,y2)(y1=data1, y2=data2)
 print(z_joint)
 
 # %%
-# We see that in this case we obtain a :class:`SingleVariablePosterior` 
+# We see that in this case we obtain a :class:`MultipleLikelihoodPosterior` 
 # object, which represents the posterior distribution of the parameters `theta`
 # given the data `y1` and `y2`. The posterior distribution in this case is 
 # proportional to the product of the two likelihoods and the prior.

--- a/tests/test_joint_distribution.py
+++ b/tests/test_joint_distribution.py
@@ -241,3 +241,28 @@ def test_extra_parameter_no_prior():
     # Joint distribution p(y,x,z)
     with pytest.raises(ValueError, match=r"Missing prior for \['b'\]"):
         cuqi.distribution.JointDistribution(y,x,z)
+
+
+def test_JointDistribution_reduce_MultipleLikelihoodPosterior():
+    """ This tests if the joint distribution can be reduced to MultipleLikelihoodPosterior """
+
+    J, data = hierarchical_joint()
+
+    # Posterior w.r.t z is with multiple likelihoods if all other parameters are fixed
+    # for this J
+    posterior_z = J(y=data, d=0.1, l=0.1, x=data)
+
+    # Check we get the right class
+    assert isinstance(posterior_z, cuqi.distribution.MultipleLikelihoodPosterior)
+
+    # Check the dimension
+    assert posterior_z.dim == 1
+
+    # Check the "prior" in multiple likelihood posterior matches z
+    assert posterior_z.prior.mean == J.get_density("z").mean
+    assert posterior_z.prior.std == J.get_density("z").std
+
+    # Check logd can be evaluated (tolerance is high since new data every time)
+    assert np.allclose(posterior_z.logd(1), -5000, atol=10)
+
+

--- a/tests/test_joint_distribution.py
+++ b/tests/test_joint_distribution.py
@@ -243,8 +243,8 @@ def test_extra_parameter_no_prior():
         cuqi.distribution.JointDistribution(y,x,z)
 
 
-def test_JointDistribution_reduce_SingleVariablePosterior():
-    """ This tests if the joint distribution can be reduced to SingleVariablePosterior """
+def test_JointDistribution_reduce_MultipleLikelihoodPosterior():
+    """ This tests if the joint distribution can be reduced to MultipleLikelihoodPosterior """
 
     J, data = hierarchical_joint()
 
@@ -259,14 +259,14 @@ def test_JointDistribution_reduce_SingleVariablePosterior():
     assert posterior_z.dim == 1
 
     # Check the "prior" in multiple likelihood posterior matches z
-    assert posterior_z.prior[0].mean == J.get_density("z").mean
-    assert posterior_z.prior[0].std == J.get_density("z").std
+    assert posterior_z.prior.mean == J.get_density("z").mean
+    assert posterior_z.prior.std == J.get_density("z").std
 
     # Check logd can be evaluated (tolerance is high since new data every time)
     assert np.allclose(posterior_z.logd(1), -5000, atol=10)
 
-def test_SingleVariablePosterior_should_raise_if_two_densities():
-    """ This tests if the SingleVariablePosterior raises if it has two densities. """
+def test_MultipleLikelihoodPosterior_should_raise_if_two_densities():
+    """ This tests if the MultipleLikelihoodPosterior raises if it has two densities. """
 
     # Define distributions for Bayesian model
     y = cuqi.distribution.Normal(lambda x: x, 1)
@@ -281,32 +281,32 @@ def test_SingleVariablePosterior_should_raise_if_two_densities():
     # Check we get the right class
     assert isinstance(P, cuqi.distribution.Posterior)
 
-    # Check that we cannot create SingleVariablePosterior
+    # Check that we cannot create MultipleLikelihoodPosterior
     with pytest.raises(ValueError, match=r"requires at least three densities"):
         cuqi.distribution.MultipleLikelihoodPosterior(y.to_likelihood(1), x)
 
 
-def test_SingleVariablePosterior_should_raise_if_no_likelihood():
-    """ This tests if the SingleVariablePosterior raises if no likelihood is given."""
+def test_MultipleLikelihoodPosterior_should_raise_if_no_likelihood():
+    """ This tests if the MultipleLikelihoodPosterior raises if no likelihood is given."""
 
     # Define distributions for Bayesian model
     y1 = cuqi.distribution.Normal(lambda x: x, 1)
     y2 = cuqi.distribution.Normal(lambda x: x+1, 1)
     x = cuqi.distribution.Normal(0, 1)
  
-    # Check that we cannot create SingleVariablePosterior
+    # Check that we cannot create MultipleLikelihoodPosterior
     with pytest.raises(ValueError, match=r"must have a likelihood and prior"):
         cuqi.distribution.MultipleLikelihoodPosterior(y1, y2, x)
 
-def test_SingleVariablePosterior_should_raise_if_names_do_not_match():
-    """ This tests if the SingleVariablePosterior raises if the names do not match."""
+def test_MultipleLikelihoodPosterior_should_raise_if_names_do_not_match():
+    """ This tests if the MultipleLikelihoodPosterior raises if the names do not match."""
 
     # Define distributions for Bayesian model
     y = cuqi.distribution.Normal(lambda x: x, 1)
     x = cuqi.distribution.Normal(0, 1)
     z = cuqi.distribution.Normal(0, 1)
  
-    # Check that we cannot create SingleVariablePosterior
+    # Check that we cannot create MultipleLikelihoodPosterior
     with pytest.raises(ValueError, match=r"the same parameter name"):
         cuqi.distribution.MultipleLikelihoodPosterior(y.to_likelihood(1), x, z)
 

--- a/tests/test_joint_distribution.py
+++ b/tests/test_joint_distribution.py
@@ -243,8 +243,8 @@ def test_extra_parameter_no_prior():
         cuqi.distribution.JointDistribution(y,x,z)
 
 
-def test_JointDistribution_reduce_MultipleLikelihoodPosterior():
-    """ This tests if the joint distribution can be reduced to MultipleLikelihoodPosterior """
+def test_JointDistribution_reduce_SingleVariablePosterior():
+    """ This tests if the joint distribution can be reduced to SingleVariablePosterior """
 
     J, data = hierarchical_joint()
 
@@ -253,16 +253,60 @@ def test_JointDistribution_reduce_MultipleLikelihoodPosterior():
     posterior_z = J(y=data, d=0.1, l=0.1, x=data)
 
     # Check we get the right class
-    assert isinstance(posterior_z, cuqi.distribution.MultipleLikelihoodPosterior)
+    assert isinstance(posterior_z, cuqi.distribution.SingleVariablePosterior)
 
     # Check the dimension
     assert posterior_z.dim == 1
 
     # Check the "prior" in multiple likelihood posterior matches z
-    assert posterior_z.prior.mean == J.get_density("z").mean
-    assert posterior_z.prior.std == J.get_density("z").std
+    assert posterior_z.priors[0].mean == J.get_density("z").mean
+    assert posterior_z.priors[0].std == J.get_density("z").std
 
     # Check logd can be evaluated (tolerance is high since new data every time)
     assert np.allclose(posterior_z.logd(1), -5000, atol=10)
 
+def test_SingleVariablePosterior_should_raise_if_two_densities():
+    """ This tests if the SingleVariablePosterior raises if it has two densities. """
+
+    # Define distributions for Bayesian model
+    y = cuqi.distribution.Normal(lambda x: x, 1)
+    x = cuqi.distribution.Normal(0, 1)
+
+    # Joint distribution p(y,x)
+    J = cuqi.distribution.JointDistribution(y,x)
+
+    # Posterior
+    P = J(y=1)
+
+    # Check we get the right class
+    assert isinstance(P, cuqi.distribution.Posterior)
+
+    # Check that we cannot create SingleVariablePosterior
+    with pytest.raises(ValueError, match=r"requires at least three densities"):
+        cuqi.distribution.SingleVariablePosterior(y.to_likelihood(1), x)
+
+
+def test_SingleVariablePosterior_should_raise_if_no_likelihood():
+    """ This tests if the SingleVariablePosterior raises if no likelihood is given."""
+
+    # Define distributions for Bayesian model
+    y1 = cuqi.distribution.Normal(lambda x: x, 1)
+    y2 = cuqi.distribution.Normal(lambda x: x+1, 1)
+    x = cuqi.distribution.Normal(0, 1)
+ 
+    # Check that we cannot create SingleVariablePosterior
+    with pytest.raises(ValueError, match=r"must have a likelihood and prior"):
+        cuqi.distribution.SingleVariablePosterior(y1, y2, x)
+
+def test_SingleVariablePosterior_should_raise_if_names_do_not_match():
+    """ This tests if the SingleVariablePosterior raises if the names do not match."""
+
+    # Define distributions for Bayesian model
+    y = cuqi.distribution.Normal(lambda x: x, 1)
+    x = cuqi.distribution.Normal(0, 1)
+    z = cuqi.distribution.Normal(0, 1)
+ 
+    # Check that we cannot create SingleVariablePosterior
+    with pytest.raises(ValueError, match=r"the same parameter name"):
+        cuqi.distribution.SingleVariablePosterior(y.to_likelihood(1), x, z)
 

--- a/tests/test_joint_distribution.py
+++ b/tests/test_joint_distribution.py
@@ -253,14 +253,14 @@ def test_JointDistribution_reduce_SingleVariablePosterior():
     posterior_z = J(y=data, d=0.1, l=0.1, x=data)
 
     # Check we get the right class
-    assert isinstance(posterior_z, cuqi.distribution.SingleVariablePosterior)
+    assert isinstance(posterior_z, cuqi.distribution.MultipleLikelihoodPosterior)
 
     # Check the dimension
     assert posterior_z.dim == 1
 
     # Check the "prior" in multiple likelihood posterior matches z
-    assert posterior_z.priors[0].mean == J.get_density("z").mean
-    assert posterior_z.priors[0].std == J.get_density("z").std
+    assert posterior_z.prior[0].mean == J.get_density("z").mean
+    assert posterior_z.prior[0].std == J.get_density("z").std
 
     # Check logd can be evaluated (tolerance is high since new data every time)
     assert np.allclose(posterior_z.logd(1), -5000, atol=10)
@@ -283,7 +283,7 @@ def test_SingleVariablePosterior_should_raise_if_two_densities():
 
     # Check that we cannot create SingleVariablePosterior
     with pytest.raises(ValueError, match=r"requires at least three densities"):
-        cuqi.distribution.SingleVariablePosterior(y.to_likelihood(1), x)
+        cuqi.distribution.MultipleLikelihoodPosterior(y.to_likelihood(1), x)
 
 
 def test_SingleVariablePosterior_should_raise_if_no_likelihood():
@@ -296,7 +296,7 @@ def test_SingleVariablePosterior_should_raise_if_no_likelihood():
  
     # Check that we cannot create SingleVariablePosterior
     with pytest.raises(ValueError, match=r"must have a likelihood and prior"):
-        cuqi.distribution.SingleVariablePosterior(y1, y2, x)
+        cuqi.distribution.MultipleLikelihoodPosterior(y1, y2, x)
 
 def test_SingleVariablePosterior_should_raise_if_names_do_not_match():
     """ This tests if the SingleVariablePosterior raises if the names do not match."""
@@ -308,5 +308,5 @@ def test_SingleVariablePosterior_should_raise_if_names_do_not_match():
  
     # Check that we cannot create SingleVariablePosterior
     with pytest.raises(ValueError, match=r"the same parameter name"):
-        cuqi.distribution.SingleVariablePosterior(y.to_likelihood(1), x, z)
+        cuqi.distribution.MultipleLikelihoodPosterior(y.to_likelihood(1), x, z)
 


### PR DESCRIPTION
Closes #123.

I left the MultipleLikelihoodPosterior in the joint distribution file because it uses both Distribution and JointDistribution, which makes theimports circular if not within the same file.

Edit: This has turned into a SingleVariablePosterior class. At the moment our joint distribution does not fully support multiple distributions for the same variable. This is because we enforce that each density must have a unique name. If we update this, the SingleVariablePosterior can work with multiple priors for the same parameter.