### PR TITLE
change get_components to regular method

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ from cuqi.distribution import Gaussian, LMRF, Gamma
 from cuqi.problem import BayesianProblem
 
 # Step 1: Set up forward model and data, y = Ax
-A, y_data, info = Deconvolution2D.get_components(dim=256, phantom="cookie")
+A, y_data, info = Deconvolution2D(dim=256, phantom="cookie").get_components()
 
 # Step 2: Define distributions for parameters
 d = Gamma(1, 1e-4)

--- a/cuqi/likelihood/__init__.py
+++ b/cuqi/likelihood/__init__.py
@@ -9,7 +9,7 @@ Create a Gaussian likelihood function from a forward `model` and observed `data`
 .. code-block:: python
 
    import cuqi
-   model, data, probInfo = cuqi.testproblem.Deconvolution1D.get_components()
+   model, data, probInfo = cuqi.testproblem.Deconvolution1D().get_components()
    likelihood = cuqi.distribution.Gaussian(mean=model, cov=0.05**2).to_likelihood(data)
 
 

--- a/cuqi/problem/_problem.py
+++ b/cuqi/problem/_problem.py
@@ -129,8 +129,8 @@ class BayesianProblem(object):
     Most functionality is currently only implemented for this simple case.
 
     """
-    @classmethod
-    def get_components(cls, **kwargs) -> Tuple[Model, CUQIarray, ProblemInfo]:
+
+    def get_components(self, **kwargs) -> Tuple[Model, CUQIarray, ProblemInfo]:
         """
         Method that returns the model, the data and additional information to be used in formulating the Bayesian problem.
         
@@ -140,13 +140,12 @@ class BayesianProblem(object):
         """
 
         problem_info = ProblemInfo() #Instead of a dict, we use our ProblemInfo dataclass.
-        problem = cls(**kwargs)
 
         for key, value in vars(problem_info).items():
-            if hasattr(problem, key):
-                setattr(problem_info,key,vars(problem)[key])
+            if hasattr(self, key):
+                setattr(problem_info,key,vars(self)[key])
 
-        return problem.model, problem.data, problem_info
+        return self.model, self.data, problem_info
 
     def __init__(self, *densities: Density, **data: np.ndarray):
         self._target = JointDistribution(*densities)(**data)

--- a/cuqi/problem/_problem.py
+++ b/cuqi/problem/_problem.py
@@ -90,7 +90,7 @@ class BayesianProblem(object):
         import matplotlib.pyplot as plt
 
         # Deterministic forward model and data (1D convolution)
-        A, y_data, probInfo = cuqi.testproblem.Deconvolution1D.get_components()
+        A, y_data, probInfo = cuqi.testproblem.Deconvolution1D().get_components()
 
         # Bayesian model
         x = cuqi.distribution.Gaussian(np.zeros(A.domain_dim), 0.1)
@@ -130,13 +130,10 @@ class BayesianProblem(object):
 
     """
 
-    def get_components(self, **kwargs) -> Tuple[Model, CUQIarray, ProblemInfo]:
+    def get_components(self) -> Tuple[Model, CUQIarray, ProblemInfo]:
         """
         Method that returns the model, the data and additional information to be used in formulating the Bayesian problem.
         
-        Parameters:
-        -----------
-        Takes the same parameters that the corresponding class initializer takes. For example: :meth:`cuqi.testproblem.Deconvolution1D.get_components` takes the parameters of :meth:`cuqi.testproblem.Deconvolution1D` constructor. 
         """
 
         problem_info = ProblemInfo() #Instead of a dict, we use our ProblemInfo dataclass.

--- a/cuqi/sampler/_gibbs.py
+++ b/cuqi/sampler/_gibbs.py
@@ -37,7 +37,7 @@ class Gibbs:
         import numpy as np
 
         # Model and data
-        A, y_obs, probinfo = cuqi.testproblem.Deconvolution1D.get_components(phantom='square')
+        A, y_obs, probinfo = cuqi.testproblem.Deconvolution1D(phantom='square').get_components()
         n = A.domain_dim
 
         # Define distributions

--- a/demos/ExploreTestProblems.ipynb
+++ b/demos/ExploreTestProblems.ipynb
@@ -84,7 +84,6 @@
     "# 2  Heat1D\n",
     "# 3  Poisson1D\n",
     "# 4  Abel1D\n",
-    "# 5  ParBeamCT2D\n",
     "\n",
     "testprob = 0\n",
     "\n",
@@ -97,10 +96,7 @@
     "elif testprob == 3:\n",
     "    model, data, probInfo = Poisson1D().get_components()\n",
     "elif testprob == 4:\n",
-    "    model, data, probInfo = Abel1D().get_components()\n",
-    "elif testprob == 5:\n",
-    "    model, data, probInfo = ParBeamCT2D(im_size=(50,50),det_count=60, proj_type=\"line\").get_components() #cuda\n",
-    "    "
+    "    model, data, probInfo = Abel1D().get_components()"
    ]
   },
   {

--- a/demos/ExploreTestProblems.ipynb
+++ b/demos/ExploreTestProblems.ipynb
@@ -89,17 +89,17 @@
     "testprob = 0\n",
     "\n",
     "if testprob == 0:\n",
-    "    model, data, probInfo = Deconvolution1D.get_components(dim=50, phantom=\"Square\")\n",
+    "    model, data, probInfo = Deconvolution1D(dim=50, phantom=\"Square\").get_components()\n",
     "elif testprob == 1:\n",
-    "    model, data, probInfo = _Deconv_1D.get_components()\n",
+    "    model, data, probInfo = _Deconv_1D().get_components()\n",
     "elif testprob == 2:\n",
-    "    model, data, probInfo = Heat1D.get_components()\n",
+    "    model, data, probInfo = Heat1D().get_components()\n",
     "elif testprob == 3:\n",
-    "    model, data, probInfo = Poisson1D.get_components()\n",
+    "    model, data, probInfo = Poisson1D().get_components()\n",
     "elif testprob == 4:\n",
-    "    model, data, probInfo = Abel1D.get_components()\n",
+    "    model, data, probInfo = Abel1D().get_components()\n",
     "elif testprob == 5:\n",
-    "    model, data, probInfo = ParBeamCT2D().get_components(im_size=(50,50),det_count=60, proj_type=\"line\") #cuda\n",
+    "    model, data, probInfo = ParBeamCT2D(im_size=(50,50),det_count=60, proj_type=\"line\").get_components() #cuda\n",
     "    "
    ]
   },
@@ -430,7 +430,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.11.5"
   },
   "vscode": {
    "interpreter": {

--- a/demos/ExploreTestProblems.ipynb
+++ b/demos/ExploreTestProblems.ipynb
@@ -430,7 +430,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.10.5"
   },
   "vscode": {
    "interpreter": {

--- a/demos/demo29_Likelihood.py
+++ b/demos/demo29_Likelihood.py
@@ -13,7 +13,7 @@ from cuqi.problem import BayesianProblem
 n = 128
 
 # %% Five line example (likelihood + prior)
-model, data, probInfo = Deconvolution1D.get_components(dim=n, phantom="Square")
+model, data, probInfo = Deconvolution1D(dim=n, phantom="Square").get_components()
 prior = Gaussian(mean=np.zeros(n), sqrtcov=0.2, name="x")
 likelihood = Gaussian(mean=model, sqrtcov=0.05, name="y").to_likelihood(data)
 IP = BayesianProblem(likelihood, prior)

--- a/demos/dev/JointDistribution.py
+++ b/demos/dev/JointDistribution.py
@@ -18,7 +18,7 @@ from cuqi.distribution import Gaussian, Gamma, JointDistribution
 from cuqi.testproblem import Deconvolution1D
 
 # Model and data
-A, y_obs, _ = Deconvolution1D.get_components()
+A, y_obs, _ = Deconvolution1D().get_components()
 
 # Model dimensions
 n = A.domain_dim

--- a/demos/howtos/Deconvolution2D.py
+++ b/demos/howtos/Deconvolution2D.py
@@ -30,7 +30,7 @@ from cuqi.problem import BayesianProblem
 # The easiest way to get these two components is to use the built-in testproblems.
 # Let us extract the model and data for a 2D deconvolution.
 
-A, y_obs, info = Deconvolution2D.get_components()
+A, y_obs, info = Deconvolution2D().get_components()
 
 # %%
 # Step 2: Prior model

--- a/demos/howtos/Defining_Posterior.py
+++ b/demos/howtos/Defining_Posterior.py
@@ -70,11 +70,8 @@ posterior.logd(np.ones(A.domain_dim))
 #    \end{align*}
 
 # Both observations come from the same unknown x
-A, y_obs, _ = cuqi.testproblem.Deconvolution1D.get_components()
-B, d_obs, _ = cuqi.testproblem.Deconvolution1D.get_components(
-    PSF="Defocus",
-    noise_std=0.02
-)
+A, y_obs, _ = cuqi.testproblem.Deconvolution1D().get_components()
+B, d_obs, _ = cuqi.testproblem.Deconvolution1D(PSF="Defocus",noise_std=0.02).get_components()
 
 # %%
 # Then consider the following Bayesian model
@@ -127,11 +124,8 @@ posterior2.logd(np.ones(A.domain_dim))
 # where :math:`C` is a nonlinear function.
 
 # Same x for all 3 observations
-A, y_obs, _ = cuqi.testproblem.Deconvolution1D.get_components()
-B, d_obs, _ = cuqi.testproblem.Deconvolution1D.get_components(
-    PSF="Defocus",
-    noise_std=0.02
-)
+A, y_obs, _ = cuqi.testproblem.Deconvolution1D().get_components()
+B, d_obs, _ = cuqi.testproblem.Deconvolution1D(PSF="Defocus", noise_std=0.02).get_components()
 C = cuqi.model.Model(lambda x: np.linalg.norm(x)**2, 1, A.domain_dim)
 b_obs = 16
 

--- a/demos/howtos/Defining_Posterior.py
+++ b/demos/howtos/Defining_Posterior.py
@@ -71,7 +71,7 @@ posterior.logd(np.ones(A.domain_dim))
 
 # Both observations come from the same unknown x
 A, y_obs, _ = cuqi.testproblem.Deconvolution1D().get_components()
-B, d_obs, _ = cuqi.testproblem.Deconvolution1D(PSF="Defocus",noise_std=0.02).get_components()
+B, d_obs, _ = cuqi.testproblem.Deconvolution1D(PSF="Defocus", noise_std=0.02).get_components()
 
 # %%
 # Then consider the following Bayesian model

--- a/demos/howtos/Defining_Posterior.py
+++ b/demos/howtos/Defining_Posterior.py
@@ -23,7 +23,7 @@ import numpy as np
 #
 # See :class:`~cuqi.testproblem.Deconvolution1D` for more details.
 
-A, y_obs, _ = cuqi.testproblem.Deconvolution1D.get_components()
+A, y_obs, _ = cuqi.testproblem.Deconvolution1D().get_components()
 
 # %%
 # Then consider the following Bayesian model

--- a/demos/try10_test_cases.py
+++ b/demos/try10_test_cases.py
@@ -9,13 +9,13 @@ import cuqi
 
 
 #%% Deconvolution Test problem
-model_deconv, data_deconv, problem_info_deconv = cuqi.testproblem.Deconvolution1D.get_components()
+model_deconv, data_deconv, problem_info_deconv = cuqi.testproblem.Deconvolution1D().get_components()
 
 #%% Deblur Test problem 
-model_deblur, data_deblur, problem_info_deblur = cuqi.testproblem._Deblur.get_components()
+model_deblur, data_deblur, problem_info_deblur = cuqi.testproblem._Deblur().get_components()
 
 #%%  Poisson1D Test problem
 KL_map = lambda x: np.exp(x)
 f = lambda xs: 10*np.exp( -( (xs - 0.5)**2 ) / 0.02) 
 
-model_poisson, data_poisson, problem_info_poisson = cuqi.testproblem.Poisson1D.get_components(dim=501, endpoint=1, source=f, field_type=None, KL_map=KL_map)
+model_poisson, data_poisson, problem_info_poisson = cuqi.testproblem.Poisson1D(dim=501, endpoint=1, source=f, field_type=None, map=KL_map).get_components()

--- a/demos/tutorials/1-Basics.py
+++ b/demos/tutorials/1-Basics.py
@@ -41,7 +41,7 @@ import cuqi
 # Let us extract the model and data for a 1D deconvolution.
 # In this case we use the default settings for the testproblem.
 
-A, y_obs, info = cuqi.testproblem.Deconvolution1D.get_components()
+A, y_obs, info = cuqi.testproblem.Deconvolution1D().get_components()
 
 # %%
 # .. todo::

--- a/demos/tutorials/Gibbs.py
+++ b/demos/tutorials/Gibbs.py
@@ -55,7 +55,7 @@ np.random.seed(0)
 # true solution (sharp signal) and data (convolved signal).
 
 # Model and data
-A, y_obs, probinfo = Deconvolution1D().get_components(phantom='square')
+A, y_obs, probinfo = Deconvolution1D(phantom='square').get_components()
 
 # Get dimension of signal
 n = A.domain_dim

--- a/demos/tutorials/Gibbs.py
+++ b/demos/tutorials/Gibbs.py
@@ -55,7 +55,7 @@ np.random.seed(0)
 # true solution (sharp signal) and data (convolved signal).
 
 # Model and data
-A, y_obs, probinfo = Deconvolution1D.get_components(phantom='square')
+A, y_obs, probinfo = Deconvolution1D().get_components(phantom='square')
 
 # Get dimension of signal
 n = A.domain_dim

--- a/demos/tutorials/JointDistribution.py
+++ b/demos/tutorials/JointDistribution.py
@@ -18,7 +18,7 @@ from cuqi.distribution import Gaussian, Gamma, JointDistribution
 from cuqi.testproblem import Deconvolution1D
 
 # Model and data
-A, y_obs, _ = Deconvolution1D.get_components()
+A, y_obs, _ = Deconvolution1D().get_components()
 
 # Model dimensions
 n = A.domain_dim

--- a/demos/tutorials/UQ_in_Deconvolution1D.py
+++ b/demos/tutorials/UQ_in_Deconvolution1D.py
@@ -36,7 +36,7 @@ import matplotlib.pyplot as plt
 # method.
 
 # Forward model and data
-A, y_data, info = cuqi.testproblem.Deconvolution1D.get_components()
+A, y_data, info = cuqi.testproblem.Deconvolution1D().get_components()
 
 # %%
 # There are many parameters that can be set when creating the test problem. For more details

--- a/demos/tutorials/UQ_in_Deconvolution1D.py
+++ b/demos/tutorials/UQ_in_Deconvolution1D.py
@@ -32,7 +32,7 @@ import matplotlib.pyplot as plt
 # This module contains a number of pre-defined test problems that contain the
 # forward model and synthetic data. In this case, we will use the
 # :class:`cuqi.testproblem.Deconvolution1D` test problem. We extract the forward model
-# and synthetic data from the test problem by calling the :func:`get_components` static
+# and synthetic data from the test problem by calling the :func:`get_components`
 # method.
 
 # Forward model and data

--- a/demos/tutorials/multiple_likelihoods.py
+++ b/demos/tutorials/multiple_likelihoods.py
@@ -110,7 +110,7 @@ else:
 	source2 = source1
 
 # Obtain the forward model from the test problem
-model2, data2, problemInfo2 = cuqi.testproblem.Poisson1D.get_components(
+model2, data2, problemInfo2 = cuqi.testproblem.Poisson1D().get_components(
     dim=dim,
     endpoint=endpoint,
     field_type=field_type,

--- a/demos/tutorials/multiple_likelihoods.py
+++ b/demos/tutorials/multiple_likelihoods.py
@@ -71,7 +71,7 @@ if set_up == "multi_observation":
 source1 = lambda xs: magnitude*np.sin(xs*2*np.pi/endpoint)+magnitude
 
 # Obtain the forward model from the test problem
-model1, data1, problemInfo1 = cuqi.testproblem.Poisson1D.get_components(
+model1, data1, problemInfo1 = cuqi.testproblem.Poisson1D().get_components(
     dim=dim,
     endpoint=endpoint,
     field_type=field_type,

--- a/demos/tutorials/multiple_likelihoods.py
+++ b/demos/tutorials/multiple_likelihoods.py
@@ -71,16 +71,14 @@ if set_up == "multi_observation":
 source1 = lambda xs: magnitude*np.sin(xs*2*np.pi/endpoint)+magnitude
 
 # Obtain the forward model from the test problem
-model1, data1, problemInfo1 = cuqi.testproblem.Poisson1D().get_components(
-    dim=dim,
+model1, data1, problemInfo1 = cuqi.testproblem.Poisson1D(dim=dim,
     endpoint=endpoint,
     field_type=field_type,
     field_params={"n_steps": n_steps},
     observation_grid_map=observation_grid_map1,
     exactSolution=x_exact,
     source=source1,
-    SNR=SNR,
-)
+    SNR=SNR).get_components()
 
 # Plot data, exact data and exact solution
 plt.figure()
@@ -110,16 +108,14 @@ else:
 	source2 = source1
 
 # Obtain the forward model from the test problem
-model2, data2, problemInfo2 = cuqi.testproblem.Poisson1D().get_components(
-    dim=dim,
+model2, data2, problemInfo2 = cuqi.testproblem.Poisson1D(dim=dim,
     endpoint=endpoint,
     field_type=field_type,
     field_params={"n_steps": n_steps},
     observation_grid_map=observation_grid_map2,
     exactSolution=x_exact,
     source=source2,
-    SNR=SNR,
-)
+    SNR=SNR).get_components()
 
 # Plot data, exact data and exact solution
 plt.figure()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -126,7 +126,7 @@ Getting started with UQ takes just a few lines of code:
    from cuqi.problem import BayesianProblem
 
    # Step 1: Set up forward model and data, y = Ax
-   A, y_data, info = Deconvolution2D.get_components(dim=256, phantom="cookie")
+   A, y_data, info = Deconvolution2D(dim=256, phantom="cookie").get_components()
 
    # Step 2: Define distributions for parameters
    d = Gamma(1, 1e-4)

--- a/tests/test_bayesian_inversion.py
+++ b/tests/test_bayesian_inversion.py
@@ -106,7 +106,7 @@ def test_Bayesian_inversion_hierarchical(TP_type: BayesianProblem, phantom: str,
     Currently, no reference data is available for this test, so no regression test is performed.
     """
     # Load model + data from testproblem library
-    A, y_data, probInfo = TP_type.get_components(dim=priors[0].dim, phantom=phantom)
+    A, y_data, probInfo = TP_type(dim=priors[0].dim, phantom=phantom).get_components()
 
     # data distribution
     if len(priors) == 1: # No hyperparameters

--- a/tests/test_joint_distribution.py
+++ b/tests/test_joint_distribution.py
@@ -5,7 +5,7 @@ import pytest
 def test_joint_dist_dim_geometry():
     """ Test the dimension and geometry properties of a joint distribution """
 
-    model, data, _ = cuqi.testproblem.Poisson1D.get_components() # Model is m times n, m != n.
+    model, data, _ = cuqi.testproblem.Poisson1D().get_components() # Model is m times n, m != n.
 
     # Bayesian model
     d = cuqi.distribution.Gamma(1, 1e-4)

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -6,7 +6,7 @@ from pytest import approx
 
 def test_likelihood_log_and_grad():
     #Create likelihood
-    model, data, probInfo = cuqi.testproblem.Deconvolution1D.get_components()
+    model, data, probInfo = cuqi.testproblem.Deconvolution1D().get_components()
     likelihood = cuqi.distribution.Gaussian(model,1).to_likelihood(data)
 
     # Tests log and gradient calls do not cause errors
@@ -14,7 +14,7 @@ def test_likelihood_log_and_grad():
     likelihood.gradient(probInfo.exactSolution)
 
 def test_likelihood_attributes():
-    model, data, _ = cuqi.testproblem.Poisson1D.get_components(dim=128, field_type="Step")
+    model, data, _ = cuqi.testproblem.Poisson1D().get_components(dim=128, field_type="Step")
     likelihood = cuqi.distribution.Gaussian(model,1).to_likelihood(data)
 
     # dim of domain
@@ -53,14 +53,14 @@ def test_likelihood_attributes():
                         cuqi.distribution.Gaussian(np.zeros(128), sqrtprec=1/np.pi*sps.eye(128)),
                         ])
 def test_likelihood_Gaussian_log_IID(dist):
-    model, data, probInfo = cuqi.testproblem.Deconvolution1D.get_components(dim=128)
+    model, data, probInfo = cuqi.testproblem.Deconvolution1D().get_components(dim=128)
     dist.mean = model
     likelihood = dist.to_likelihood(probInfo.exactData) #We use exact data to get same logpdf every time
     assert likelihood.logd(probInfo.exactSolution) == approx(-264.14955763892135)
 
 def test_likelihood_UserDefined():
     # CUQI likelihood
-    model, data, probInfo = cuqi.testproblem.Deconvolution1D.get_components()
+    model, data, probInfo = cuqi.testproblem.Deconvolution1D().get_components()
     L = cuqi.distribution.Gaussian(model, 1).to_likelihood(data)
 
     # Create user defined likelihood

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -14,7 +14,7 @@ def test_likelihood_log_and_grad():
     likelihood.gradient(probInfo.exactSolution)
 
 def test_likelihood_attributes():
-    model, data, _ = cuqi.testproblem.Poisson1D().get_components(dim=128, field_type="Step")
+    model, data, _ = cuqi.testproblem.Poisson1D(dim=128, field_type="Step").get_components()
     likelihood = cuqi.distribution.Gaussian(model,1).to_likelihood(data)
 
     # dim of domain
@@ -53,7 +53,7 @@ def test_likelihood_attributes():
                         cuqi.distribution.Gaussian(np.zeros(128), sqrtprec=1/np.pi*sps.eye(128)),
                         ])
 def test_likelihood_Gaussian_log_IID(dist):
-    model, data, probInfo = cuqi.testproblem.Deconvolution1D().get_components(dim=128)
+    model, data, probInfo = cuqi.testproblem.Deconvolution1D(dim=128).get_components()
     dist.mean = model
     likelihood = dist.to_likelihood(probInfo.exactData) #We use exact data to get same logpdf every time
     assert likelihood.logd(probInfo.exactSolution) == approx(-264.14955763892135)

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -438,7 +438,7 @@ def _Gibbs_joint_hier_model(use_legacy=False, noise_std=0.01):
     np.random.seed(0)
     
     # Model and data
-    A, y_obs, _ = cuqi.testproblem.Deconvolution1D.get_components(phantom='square', use_legacy=use_legacy, noise_std=noise_std)
+    A, y_obs, _ = cuqi.testproblem.Deconvolution1D(phantom='square', use_legacy=use_legacy, noise_std=noise_std).get_components()
     n = A.domain_dim
 
     # Define distributions


### PR DESCRIPTION
This PR fixed #47 by changing `get_components` from a class method to a regular/instance method.

The following snippet is used to check if the returned components are as expected:
```Python
# %%
import cuqi
from cuqi.testproblem import Deconvolution1D
import matplotlib.pyplot as plt

# %% setup problems
dim = [32, 128]
phantom = ["pc","bumps"]
noise_type = ["Gaussian","ScaledGaussian"]
noise_std = [0.05, 0.0001]

# Test problems
prob0 = Deconvolution1D(
    dim = dim[0],
    phantom=phantom[0],
    noise_type=noise_type[0],
    noise_std = noise_std[0]
)
prob1 = Deconvolution1D(
    dim = dim[1],
    phantom=phantom[1],
    noise_type=noise_type[1],
    noise_std = noise_std[1]
)

# %% use get_components to extract information
A0, y_data0, probInfo0 = prob0.get_components()
A1, y_data1, probInfo1 = prob1.get_components()

# check if the extraced y_datax are as expected
plt.figure()
y_data0.plot()
plt.figure()
y_data1.plot()
```
and the plots are like:
![image](https://github.com/CUQI-DTU/CUQIpy/assets/69794131/6459c131-4b80-4066-be3b-24e6c1b0fe37)
and 
![image](https://github.com/CUQI-DTU/CUQIpy/assets/69794131/be987b8a-0a7b-4e11-8ea0-676fa4058302)
 