### PR TITLE
Bump minimum supported python version, add latest python versions to testing and update maintainers in toml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest] # Add windows-latest, macos-latest to test on multiple OS
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ maintainers = [
     {name = "Amal M. Alghamdi", email = "amaal@dtu.dk"}
 ]
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = {file = "LICENSE"}
 dynamic = ["dependencies", "version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ description = "Computational Uncertainty Quantification for Inverse problems in 
 maintainers = [
     {name = "Nicolai A. B. Riis", email = "nabr@dtu.dk"},
     {name = "Jakob S. Jørgensen", email = "jakj@dtu.dk"},
-    {name = "Amal M. Alghamdi", email = "amaal@dtu.dk"}
+    {name = "Amal M. Alghamdi", email = "amaal@dtu.dk"},
+    {name = "Chao Zhang", email = "chaz@dtu.dk"}
 ]
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
Closes #304 

We agreed to remove support for python 3.7 as one of our dependancies stopped supporting it.