### PR TITLE
update demos/demo35_FD_gradient.py to test NUTS and ULA with FD approximated gradients

### DIFF
--- a/demos/demo35_FD_gradient.py
+++ b/demos/demo35_FD_gradient.py
@@ -11,8 +11,10 @@ posterior = TP.posterior
 #%% Sample from the posterior using Metropolis-Hastings
 print('Sampling from the posterior using Metropolis-Hastings:')
 MH_sampler = cuqi.sampler.MH(posterior)
-MH_samples = MH_sampler.sample_adapt(1000)
+MH_samples = MH_sampler.sample_adapt(1000, 100)
+plt.figure()
 MH_samples.plot_ci(95,exact=TP.exactSolution)
+plt.title("MH")
 
 #%% Sample from the posterior using MALA
 print('Sampling from the posterior using MALA:')
@@ -22,19 +24,37 @@ try:
     MALA_samples = MALA_sampler.sample_adapt(1000)
 except Exception as e:
     print(e)
+print('Sampling failed because the gradient of the posterior is not available.')
 
-print('Sampling failed because the gradient of the posterior is not available.') 
+#%%
 print('Enable finite difference approximation of the gradient ' +
-      'for the posterior, and attempt sampling again using MALA:')
+      'for the posterior, and attempt sampling again using MALA, ULA and NUTS:')
 
 posterior.enable_FD()
 MALA_sampler = cuqi.sampler.MALA(posterior, 0.0001)
-MALA_samples = MALA_sampler.sample_adapt(1000)
+MALA_samples = MALA_sampler.sample_adapt(1000, 10)
 plt.figure()
 MALA_samples.plot_ci(95,exact=TP.exactSolution)
+plt.title("MALA")
 
-#%% Plot the ESS of the two chains
+#%% Sample from the posterior using ULA
+ULA_sampler = cuqi.sampler.ULA(posterior, 0.0001)
+ULA_samples = ULA_sampler.sample_adapt(1000, 10)
+plt.figure()
+ULA_samples.plot_ci(95,exact=TP.exactSolution)
+plt.title("ULA")
+
+#%% Sample from the posterior using NUTS
+NUTS_sampler = cuqi.sampler.NUTS(posterior)
+NUTS_samples = NUTS_sampler.sample_adapt(1000, 10)
+plt.figure()
+NUTS_samples.plot_ci(95, exact=TP.exactSolution)
+plt.title("NUTS")
+
+#%% Plot the ESS of all the chains
 plt.figure()
 plt.plot(MH_samples.compute_ess(), label='MH ESS', marker='o')
 plt.plot(MALA_samples.compute_ess(), label='MALA ESS', marker='o')
+plt.plot(ULA_samples.compute_ess(), label='ULA ESS', marker='o')
+plt.plot(NUTS_samples.compute_ess(), label='NUTS ESS', marker='o')
 plt.legend()


### PR DESCRIPTION
- related to #157 but didn't find any problem with the current implementation of NUTS when working with FD-approximated gradients
- updated `demos/demo35_FD_gradient.py` so that MALA, ULA and NUTS are tested with FD-approximated gradients
Some plots from running `demos/demo35_FD_gradient.py`:
![output_nuts](https://github.com/CUQI-DTU/CUQIpy/assets/69794131/719974e2-b283-4c11-9a1c-c6a37cd6f31e)
![output_ess](https://github.com/CUQI-DTU/CUQIpy/assets/69794131/30b89f94-2769-4b90-9642-045b848c7035)

This closes #157 for now but feel free to reopen if any bug re-appears in the future.
