### PR TITLE
rename precision from Laplace distribution to scale

### DIFF
--- a/cuqi/distribution/_laplace.py
+++ b/cuqi/distribution/_laplace.py
@@ -4,7 +4,7 @@ from cuqi.distribution import Distribution
 class Laplace(Distribution):
     """ Laplace distribution. 
 
-    Defines a Laplace distribution given a location and a precision. The Laplace distribution is defined as
+    Defines a Laplace distribution given a location and a rate parameter. The Laplace distribution is defined as
 
     .. math::
 
@@ -12,7 +12,7 @@ class Laplace(Distribution):
 
     where :math:`\mu` is the location and :math:`b` is the scale parameter.
 
-    The precision is defined as :math:`\lambda = \\frac{1}{b}`.
+    The rate parameter is defined as :math:`\lambda = \\frac{1}{b}`.
 
     The variables of this Laplace distribution are independent identically distributed (i.i.d.).
 
@@ -21,27 +21,27 @@ class Laplace(Distribution):
     location : scalar or ndarray
         The location parameter of the distribution.
 
-    prec : scalar
-        The precision parameter of the distribution.
+    rate : scalar
+        The rate parameter of the distribution.
 
     """
 
-    def __init__(self, location, prec, **kwargs):
+    def __init__(self, location, rate, **kwargs):
 
         # Init from abstract distribution class
         super().__init__(**kwargs)
 
         self.location = location
-        self.prec = prec
+        self.rate = rate
   
     def logpdf(self, x):
         if isinstance(x, (float,int)):
             x = np.array([x])
-        return self.dim*(np.log(self.prec/2)) - self.prec*np.linalg.norm(x-self.location,1)
+        return self.dim*(np.log(self.rate/2)) - self.rate*np.linalg.norm(x-self.location,1)
 
     def _sample(self,N=1,rng=None):
         if rng is not None:
-            s =  rng.laplace(self.location, 1.0/self.prec, (N,self.dim)).T
+            s =  rng.laplace(self.location, 1.0/self.rate, (N,self.dim)).T
         else:
-            s = np.random.laplace(self.location, 1.0/self.prec, (N,self.dim)).T
+            s = np.random.laplace(self.location, 1.0/self.rate, (N,self.dim)).T
         return s

--- a/cuqi/distribution/_laplace.py
+++ b/cuqi/distribution/_laplace.py
@@ -37,7 +37,7 @@ class Laplace(Distribution):
     def logpdf(self, x):
         if isinstance(x, (float,int)):
             x = np.array([x])
-        return self.dim*(np.log(0.5*self.scale)) - np.linalg.norm(x-self.location,1)/self.scale
+        return self.dim*(np.log(0.5/self.scale)) - np.linalg.norm(x-self.location,1)/self.scale
 
     def _sample(self,N=1,rng=None):
         if rng is not None:

--- a/cuqi/distribution/_laplace.py
+++ b/cuqi/distribution/_laplace.py
@@ -4,13 +4,13 @@ from cuqi.distribution import Distribution
 class Laplace(Distribution):
     """ Laplace distribution. 
 
-    Defines a Laplace distribution given a location and a rate parameter. The Laplace distribution is defined as
+    Defines a Laplace distribution given a location and a scale. The Laplace distribution is defined as
 
     .. math::
 
         p(x) = \\frac{1}{2b} \exp\left(-\\frac{|x-\mu|}{b}\\right),
 
-    where :math:`\mu` is the location and :math:`b` is the scale parameter.
+    where :math:`\mu` is the location (mean) and :math:`b` is the scale (decay) parameter.
 
     The rate parameter is defined as :math:`\lambda = \\frac{1}{b}`.
 
@@ -21,18 +21,19 @@ class Laplace(Distribution):
     location : scalar or ndarray
         The location parameter of the distribution.
 
-    rate : scalar
-        The rate parameter of the distribution.
+    scale : scalar
+        The scale parameter of the distribution.
 
     """
 
-    def __init__(self, location, rate, **kwargs):
+    def __init__(self, location, scale, **kwargs):
 
         # Init from abstract distribution class
         super().__init__(**kwargs)
 
         self.location = location
-        self.rate = rate
+        self.scale = scale
+        self.rate = 1.0/self.scale
   
     def logpdf(self, x):
         if isinstance(x, (float,int)):

--- a/cuqi/distribution/_laplace.py
+++ b/cuqi/distribution/_laplace.py
@@ -33,16 +33,15 @@ class Laplace(Distribution):
 
         self.location = location
         self.scale = scale
-        self.rate = 1.0/self.scale
   
     def logpdf(self, x):
         if isinstance(x, (float,int)):
             x = np.array([x])
-        return self.dim*(np.log(self.rate/2)) - self.rate*np.linalg.norm(x-self.location,1)
+        return self.dim*(np.log(0.5*self.scale)) - np.linalg.norm(x-self.location,1)/self.scale
 
     def _sample(self,N=1,rng=None):
         if rng is not None:
-            s =  rng.laplace(self.location, 1.0/self.rate, (N,self.dim)).T
+            s =  rng.laplace(self.location, self.scale, (N,self.dim)).T
         else:
-            s = np.random.laplace(self.location, 1.0/self.rate, (N,self.dim)).T
+            s = np.random.laplace(self.location, self.scale, (N,self.dim)).T
         return s

--- a/demos/demo15_test_LMRF.py
+++ b/demos/demo15_test_LMRF.py
@@ -23,11 +23,6 @@ print(y.pdf(1))
 samples = y.sample(1000)
 
 # %%
-from scipy.stats import laplace
-print(laplace.pdf(6))
-print(laplace.pdf(1))
-
-# %%
 plt.figure()
 samples.plot_chain(0)
 #samples.plot()

--- a/demos/demo15_test_LMRF.py
+++ b/demos/demo15_test_LMRF.py
@@ -26,7 +26,7 @@ samples = y.sample(1000)
 from scipy.stats import laplace
 print(laplace.pdf(6))
 print(laplace.pdf(1))
-assert np.allclose(y.pdf(6), laplace.pdf(6)) and np.allclose(y.pdf(1), laplace.pdf(1))
+assert np.isclose(y.pdf(6), laplace.pdf(6)) and np.isclose(y.pdf(1), laplace.pdf(1))
 
 # %%
 plt.figure()

--- a/demos/demo15_test_LMRF.py
+++ b/demos/demo15_test_LMRF.py
@@ -6,7 +6,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import scipy
 import cuqi.operator
-#%%
+# %%
 location = 0
 N = 2
 scale = 1.0
@@ -14,7 +14,7 @@ dom = 1
 BCs = 'neumann'
 x = cuqi.distribution.LMRF(location, scale, BCs, geometry=N)
 print(x.logd(np.array([3,4])))
-#%%
+# %%
 location = 0
 scale = 1
 y = cuqi.distribution.Laplace(location, scale)
@@ -22,10 +22,11 @@ print(y.pdf(6))
 print(y.pdf(1))
 samples = y.sample(1000)
 
-#%%
+# %%
 from scipy.stats import laplace
 print(laplace.pdf(6))
 print(laplace.pdf(1))
+assert np.allclose(y.pdf(6), laplace.pdf(6)) and np.allclose(y.pdf(1), laplace.pdf(1))
 
 # %%
 plt.figure()

--- a/demos/demo15_test_LMRF.py
+++ b/demos/demo15_test_LMRF.py
@@ -26,7 +26,6 @@ samples = y.sample(1000)
 from scipy.stats import laplace
 print(laplace.pdf(6))
 print(laplace.pdf(1))
-assert np.isclose(y.pdf(6), laplace.pdf(6)) and np.isclose(y.pdf(1), laplace.pdf(1))
 
 # %%
 plt.figure()

--- a/demos/demo15_test_LMRF.py
+++ b/demos/demo15_test_LMRF.py
@@ -9,15 +9,15 @@ import cuqi.operator
 #%%
 location = 0
 N = 2
-prec = 1.0
+scale = 1.0
 dom = 1
 BCs = 'neumann'
-x = cuqi.distribution.LMRF(location, prec, BCs, geometry=N)
+x = cuqi.distribution.LMRF(location, scale, BCs, geometry=N)
 print(x.logd(np.array([3,4])))
 #%%
 location = 0
-prec = 1
-y = cuqi.distribution.Laplace(location, prec)
+scale = 1
+y = cuqi.distribution.Laplace(location, scale)
 print(y.pdf(6))
 print(y.pdf(1))
 samples = y.sample(1000)

--- a/demos/try12_Deconvolution_BayesianProblem.py
+++ b/demos/try12_Deconvolution_BayesianProblem.py
@@ -33,10 +33,10 @@ TP.prior = CMRF(location=0, scale=0.01, bc_type="zero", geometry=TP.model.domain
 #TP.prior = LMRF(location=0, scale=0.01, bc_type="neumann", geometry=TP.model.domain_geometry)
 
 # Bad choices (ignore) both 1D and 2D
-# TP.prior = Beta(2*np.ones(n), 5*np.ones(n)) #Might need tuning
-# TP.prior = Laplace(np.zeros(n), 1/10) #Might need tuning
-# TP.prior = InverseGamma(3*np.ones(n), np.zeros(n), 1*np.ones(n)) #Bad choice in general.. #Might need tuning
-# TP.prior = Lognormal(mean=np.zeros(n), cov=0.05) #NUTS ACTS out!
+#TP.prior = Beta(2*np.ones(n), 5*np.ones(n)) #Might need tuning
+#TP.prior = Laplace(np.zeros(n), 1/10) #Might need tuning
+#TP.prior = InverseGamma(3*np.ones(n), np.zeros(n), 1*np.ones(n)) #Bad choice in general.. #Might need tuning
+#TP.prior = Lognormal(mean=np.zeros(n), cov=0.05) #NUTS ACTS out!
 
 # %% Samples
 samples = TP.sample_posterior(Ns)

--- a/demos/try12_Deconvolution_BayesianProblem.py
+++ b/demos/try12_Deconvolution_BayesianProblem.py
@@ -33,10 +33,10 @@ TP.prior = CMRF(location=0, scale=0.01, bc_type="zero", geometry=TP.model.domain
 #TP.prior = LMRF(location=0, scale=0.01, bc_type="neumann", geometry=TP.model.domain_geometry)
 
 # Bad choices (ignore) both 1D and 2D
-#TP.prior = Beta(2*np.ones(n), 5*np.ones(n)) #Might need tuning
-#TP.prior = Laplace(np.zeros(n), 10) #Might need tuning
-#TP.prior = InverseGamma(3*np.ones(n), np.zeros(n), 1*np.ones(n)) #Bad choice in general.. #Might need tuning
-#TP.prior = Lognormal(mean=np.zeros(n), cov=0.05) #NUTS ACTS out!
+# TP.prior = Beta(2*np.ones(n), 5*np.ones(n)) #Might need tuning
+# TP.prior = Laplace(np.zeros(n), 1/10) #Might need tuning
+# TP.prior = InverseGamma(3*np.ones(n), np.zeros(n), 1*np.ones(n)) #Bad choice in general.. #Might need tuning
+# TP.prior = Lognormal(mean=np.zeros(n), cov=0.05) #NUTS ACTS out!
 
 # %% Samples
 samples = TP.sample_posterior(Ns)

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -372,6 +372,13 @@ def test_InverseGamma(a, location, scale, x, func):
     else:
         raise ValueError
 
+@pytest.mark.parametrize("location", [-1, -2, -3, 0, 1, 2, 3])
+@pytest.mark.parametrize("scale", [1e-3, 1e-1, 1e0, 1e1, 1e3])
+@pytest.mark.parametrize("value", [1e-3, 1e-1, 1e0, 1e1, 1e3])
+def test_Laplace_pdf(location, scale, value):
+    LPL = cuqi.distribution.Laplace(location, scale)
+    assert np.isclose(LPL.pdf(value), scipy_stats.laplace(location, scale).pdf(value))
+
 @pytest.mark.xfail(reason="Expected to fail after fixing Gaussian sample. Regression needs to be updated")
 def test_lognormal_sample():
     rng = np.random.RandomState(3)


### PR DESCRIPTION
Closes #293 by using `scale`, instead of `prec` to initialize Laplace `cuqi.distribution.Laplace`