### PR TITLE
Sprint27 beta grad

### DIFF
--- a/cuqi/distribution/_beta.py
+++ b/cuqi/distribution/_beta.py
@@ -69,7 +69,7 @@ class Beta(Distribution):
     def _sample(self, N=1, rng=None):
         return sps.beta.rvs(a=self.alpha, b=self.beta, size=(N,self.dim), random_state=rng).T
 
-    def _gradient(self, x):
+    def _gradient(self, x, *args, **kwargs):
         #Avoid complicated geometries that change the gradient.
         if not type(self.geometry) in _get_identity_geometries():
             raise NotImplementedError("Gradient not implemented for distribution {} with geometry {}".format(self,self.geometry))

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -589,6 +589,31 @@ def test_beta(): #TODO. Make more tests
     FD_gradient = cuqi.utilities.approx_gradient(BD.logpdf, x, epsilon=0.000000001)
     assert np.allclose(BD.gradient(x),FD_gradient,rtol=1e-3) or (np.all(np.isnan(FD_gradient)) and np.all(np.isnan(BD.gradient(x))))
 
+# Fixture for beta distribution where beta is a likelihood
+@pytest.fixture
+def beta_likelihood():
+    # simple forward model
+    A = cuqi.model.Model(
+        lambda x: x**2,
+        range_geometry=1,
+        domain_geometry=1,
+        gradient=lambda direction, wrt: 2*wrt*direction)
+    
+    # set a gaussian prior
+    x = cuqi.distribution.Gaussian(0, 1)
+    # Beta data distribution
+    y = cuqi.distribution.Beta(A(x),1)
+    # set the observed data
+    y=y(y=0.5)
+    return y
+
+def test_gradient_for_Beta_as_likelihood_raises_error(beta_likelihood):
+    """Test computing the gradient of the Beta distribution as a likelihood
+    raises a NotImplementedError"""
+
+    with pytest.raises(NotImplementedError, 
+                       match=r"Gradient is not implemented for CUQI Beta."):
+        beta_likelihood.gradient(1)
 
 @pytest.mark.parametrize("C",[1, np.ones(5), np.eye(5), sps.eye(5), sps.diags(np.ones(5))])
 def test_Gaussian_Cov_sample(C):


### PR DESCRIPTION
closes #159 

There is an error raised already in the case described which state: "NotImplementedError: Gradient is not implemented for CUQI Beta. Conditioning variables ['x']. with conditioning variables ['x']". However, computing the gradient for Beta likelihood used to (before this PR) fail for another reason: Beta._gradient() takes 2 positional arguments but 3 were given. I fixed the latter error by updating the gradient argument to be consistent with, e.g., Gaussian gradient. I also added a test. Now the first error is raised when attempting to compute the gradient for Beta likelihood. 