### PR TITLE
Sampler rework: refactor CWMH sampler

### DIFF
--- a/cuqi/experimental/mcmc/__init__.py
+++ b/cuqi/experimental/mcmc/__init__.py
@@ -4,3 +4,4 @@ from ._sampler import SamplerNew, ProposalBasedSamplerNew
 from ._langevin_algorithm import MALANew
 from ._mh import MHNew
 from ._pcn import pCNNew
+from ._cwmh import CWMHNew

--- a/cuqi/experimental/mcmc/_cwmh.py
+++ b/cuqi/experimental/mcmc/_cwmh.py
@@ -124,6 +124,8 @@ class CWMHNew(ProposalBasedSamplerNew):
             raise ValueError(fail_msg)
 
     def step(self): #CWMH_new
+        """ Perform one step of the sampler by transitioning the current point
+        to a new point according to the sampler's transition kernel. """
         # Propose state x_i_star used to update
         # each component of x_t step by step
         x_t = self.current_point.copy()
@@ -166,6 +168,8 @@ class CWMHNew(ProposalBasedSamplerNew):
         return acc
 
     def tune(self, skip_len, update_count):
+        """ Tune the parameters of the sampler. This method is called after each
+        step of the warmup phase. """
         idx = update_count
         star_acc = 0.21/self.dim + 0.23
         hat_acc = np.mean(self._acc[idx*skip_len:(idx+1)*skip_len], axis=0)

--- a/cuqi/experimental/mcmc/_cwmh.py
+++ b/cuqi/experimental/mcmc/_cwmh.py
@@ -123,7 +123,7 @@ class CWMHNew(ProposalBasedSamplerNew):
         else:
             raise ValueError(fail_msg)
 
-    def step(self): #CWMH_new
+    def step(self):
         """ Perform one step of the sampler by transitioning the current point
         to a new point according to the sampler's transition kernel. """
         # Propose state x_i_star used to update

--- a/cuqi/experimental/mcmc/_cwmh.py
+++ b/cuqi/experimental/mcmc/_cwmh.py
@@ -1,0 +1,149 @@
+import numpy as np
+import cuqi
+from cuqi.mcmc import ProposalBasedSamplerNew
+from cuqi.array import CUQIarray
+
+class CWMH_new(ProposalBasedSamplerNew):
+    """Component-wise Metropolis Hastings sampler.
+
+    Allows sampling of a target distribution by a component-wise random-walk sampling of a proposal distribution along with an accept/reject step.
+
+    Parameters
+    ----------
+
+    target : `cuqi.distribution.Distribution` or lambda function
+        The target distribution to sample. Custom logpdfs are supported by using a :class:`cuqi.distribution.UserDefinedDistribution`.
+    
+    proposal : `cuqi.distribution.Distribution` or callable method
+        The proposal to sample from. If a callable method it should provide a single independent sample from proposal distribution. Defaults to a Gaussian proposal.  *Optional*.
+
+    scale : float
+        Scale parameter used to define correlation between previous and proposed sample in random-walk.  *Optional*.
+
+    x0 : ndarray
+        Initial parameters. *Optional*
+
+    dim : int
+        Dimension of parameter space. Required if target and proposal are callable functions. *Optional*.
+
+    callback : callable, *Optional*
+        If set this function will be called after every sample.
+        The signature of the callback function is `callback(sample, sample_index)`,
+        where `sample` is the current sample and `sample_index` is the index of the sample.
+        An example is shown in demos/demo31_callback.py.
+
+    Example
+    -------
+    .. code-block:: python
+
+        # Parameters
+        dim = 5 # Dimension of distribution
+        mu = np.arange(dim) # Mean of Gaussian
+        std = 1 # standard deviation of Gaussian
+
+        # Logpdf function
+        logpdf_func = lambda x: -1/(std**2)*np.sum((x-mu)**2)
+
+        # Define distribution from logpdf as UserDefinedDistribution (sample and gradients also supported as inputs to UserDefinedDistribution)
+        target = cuqi.distribution.UserDefinedDistribution(dim=dim, logpdf_func=logpdf_func)
+
+        # Set up sampler
+        sampler = cuqi.sampler.CWMH(target, scale=1)
+
+        # Sample
+        samples = sampler.sample(2000)
+
+    """
+    def __init__(self, target: cuqi.density.Density, proposal=None, scale=1,
+                 initial_point=None, dim=None, **kwargs):
+        super().__init__(target, proposal=proposal, scale=scale,
+                         x0=initial_point, dim=dim, **kwargs)
+
+    @ProposalBasedSamplerNew.proposal.setter 
+    def proposal(self, value):
+        fail_msg = "Proposal should be either None, "+\
+            f"{self.distribution.Distribution.__class__.__name__} "+\
+            "conditioned only on 'location' and 'scale', lambda function, "+\
+            f"or {self.distribution.Normal.__class__.__name__} conditioned "+\
+            "only on 'mean' and 'std'"
+
+        if value is None:
+            self._proposal = cuqi.distribution.Normal(mean = lambda location:location,std = lambda scale:scale, geometry=self.dim)
+
+        elif isinstance(value, cuqi.distribution.Distribution) and sorted(value.get_conditioning_variables())==['location','scale']:
+            self._proposal = value
+
+        elif isinstance(value, cuqi.distribution.Normal) and sorted(value.get_conditioning_variables())==['mean','std']:
+            self._proposal = value(mean = lambda location:location, std = lambda scale:scale)
+
+        elif not isinstance(value, cuqi.distribution.Distribution) and callable(value):
+            self._proposal = value
+
+        else:
+            raise ValueError(fail_msg)
+        
+        #self._proposal.geometry = self.target.geometry
+
+    def step(self, x_t, target_eval_t): #CWMH_new
+        # Propose state x_i_star used to update x_t
+        # each component of x_t step by step 
+        if isinstance(self.proposal,cuqi.distribution.Distribution):
+            x_i_star = self.proposal(location= x_t, scale = self.scale).sample()
+        else:
+            x_i_star = self.proposal(x_t, self.scale) 
+        x_star = x_t.copy()
+        acc = np.zeros(self.dim)
+
+        for j in range(self.dim):
+            # propose state
+            x_star[j] = x_i_star[j]
+
+            # evaluate target
+            target_eval_star = self.target.logd(x_star)
+
+            # ratio and acceptance probability
+            ratio = target_eval_star - target_eval_t  # proposal is symmetric
+            alpha = min(0, ratio)
+
+            # accept/reject
+            u_theta = np.log(np.random.rand())
+            if (u_theta <= alpha):
+                x_t[j] = x_i_star[j]
+                target_eval_t = target_eval_star
+                acc[j] = 1
+            else:
+                pass
+                # x_t[j]       = x_t[j]
+                # target_eval_t = target_eval_t
+            x_star = x_t.copy()
+        self.current_point = x_t.copy()
+        self.current_target = target_eval_t
+        #NEW: update return 
+        #return x_t, target_eval_t, acc
+        return acc
+
+
+    def tune(self, skip_len, update_count): #CWMH_new
+        # hat_acc = np.mean(self._acc[-1-skip_len:])
+
+        # # d. compute new scaling parameter
+        # zeta = 1/np.sqrt(update_count+1)   # ensures that the variation of lambda(i) vanishes
+        # scale_temp = np.exp(np.log(self.scale) + zeta*(hat_acc-0.234))
+
+        # # update parameters
+        # self.scale = min(scale_temp, 1)
+        raise NotImplementedError("Tuning not implemented for CWMH_new")
+
+    def get_state(self):
+
+        return {'sampler_type': 'CWMH', 'current_point': self.current_point.to_numpy(), 'current_target': self.current_target.to_numpy(), 'scale': self.scale.to_numpy()}
+
+    def set_state(self, state):
+        self.current_point =\
+            CUQIarray(state['current_point'] , geometry=self.target.geometry)
+
+        self.current_target =\
+            CUQIarray(state['current_target'] , geometry=self.target.geometry)
+
+        self.scale =\
+            CUQIarray(state['scale'] , geometry=self.target.geometry)

--- a/cuqi/experimental/mcmc/_cwmh.py
+++ b/cuqi/experimental/mcmc/_cwmh.py
@@ -1,6 +1,6 @@
 import numpy as np
 import cuqi
-from cuqi.mcmc import ProposalBasedSamplerNew
+from cuqi.experimental.mcmc import ProposalBasedSamplerNew
 from cuqi.array import CUQIarray
 
 class CWMHNew(ProposalBasedSamplerNew):

--- a/cuqi/experimental/mcmc/_cwmh.py
+++ b/cuqi/experimental/mcmc/_cwmh.py
@@ -31,10 +31,6 @@ class CWMHNew(ProposalBasedSamplerNew):
     initial_point : ndarray
         Initial parameters. *Optional*
 
-    dim : int
-        Dimension of parameter space. Required if target and proposal are
-        callable functions. *Optional*.
-
     callback : callable, *Optional*
         If set this function will be called after every sample.
         The signature of the callback function is
@@ -97,7 +93,10 @@ class CWMHNew(ProposalBasedSamplerNew):
         self._scale_temp = self._scale.copy()
 
     def validate_target(self):
-        pass # All targets are valid
+        if not isinstance(self.target, cuqi.density.Density):
+            raise ValueError(
+                "Target should be an instance of "+\
+                f"{cuqi.density.Density.__class__.__name__}")
 
     @ProposalBasedSamplerNew.proposal.setter
     # TODO. Check if we can refactor this.

--- a/cuqi/experimental/mcmc/_cwmh.py
+++ b/cuqi/experimental/mcmc/_cwmh.py
@@ -75,16 +75,26 @@ class CWMHNew(ProposalBasedSamplerNew):
                  initial_point=None, **kwargs):
         super().__init__(target, proposal=proposal, scale=scale,
                          initial_point=initial_point, **kwargs)
-        # Set scale
-        if isinstance(scale, Number):
-            self.scale = np.ones(self.dim)*scale
-            self._scale_temp = np.ones(self.dim)*scale
-        elif isinstance(scale, np.ndarray):
-            self.scale = scale
-            self._scale_temp = scale.copy()
+
+        # set initial scale
+        self.scale = scale
 
         # set initial acceptance rate
         self._acc = [np.ones((self.dim))]
+
+    @property
+    def scale(self):
+        """ Get the scale parameter. """
+        return self._scale
+
+    @scale.setter
+    def scale(self, value):
+        """ Set the scale parameter. """
+        if isinstance(value, Number):
+            self._scale = np.ones(self.dim)*value
+        elif isinstance(value, np.ndarray):
+            self._scale = value
+        self._scale_temp = self._scale.copy()
 
     def validate_target(self):
         pass # All targets are valid

--- a/cuqi/experimental/mcmc/_cwmh.py
+++ b/cuqi/experimental/mcmc/_cwmh.py
@@ -100,7 +100,7 @@ class CWMHNew(ProposalBasedSamplerNew):
         pass # All targets are valid
 
     @ProposalBasedSamplerNew.proposal.setter
-     # TODO. Check if we can refactor this.
+    # TODO. Check if we can refactor this.
     # We can work with a validate_proposal method instead?
     def proposal(self, value):
         fail_msg = "Proposal should be either None, "+\

--- a/cuqi/experimental/mcmc/_cwmh.py
+++ b/cuqi/experimental/mcmc/_cwmh.py
@@ -7,16 +7,20 @@ from numbers import Number
 class CWMHNew(ProposalBasedSamplerNew):
     """Component-wise Metropolis Hastings sampler.
 
-    Allows sampling of a target distribution by a component-wise random-walk sampling of a proposal distribution along with an accept/reject step.
+    Allows sampling of a target distribution by a component-wise random-walk
+    sampling of a proposal distribution along with an accept/reject step.
 
     Parameters
     ----------
 
     target : `cuqi.distribution.Distribution` or lambda function
-        The target distribution to sample. Custom logpdfs are supported by using a :class:`cuqi.distribution.UserDefinedDistribution`.
+        The target distribution to sample. Custom logpdfs are supported by using
+        a :class:`cuqi.distribution.UserDefinedDistribution`.
     
     proposal : `cuqi.distribution.Distribution` or callable method
-        The proposal to sample from. If a callable method it should provide a single independent sample from proposal distribution. Defaults to a Gaussian proposal.  *Optional*.
+        The proposal to sample from. If a callable method it should provide a
+        single independent sample from proposal distribution. Defaults to a
+        Gaussian proposal.  *Optional*.
 
     scale : float or ndarray
         Scale parameter used to define correlation between previous and proposed
@@ -28,16 +32,19 @@ class CWMHNew(ProposalBasedSamplerNew):
         Initial parameters. *Optional*
 
     dim : int
-        Dimension of parameter space. Required if target and proposal are callable functions. *Optional*.
+        Dimension of parameter space. Required if target and proposal are
+        callable functions. *Optional*.
 
     callback : callable, *Optional*
         If set this function will be called after every sample.
-        The signature of the callback function is `callback(sample, sample_index)`,
-        where `sample` is the current sample and `sample_index` is the index of the sample.
+        The signature of the callback function is
+        `callback(sample, sample_index)`, where `sample` is the current sample
+        and `sample_index` is the index of the sample.
         An example is shown in demos/demo31_callback.py.
 
     kwargs : dict
-        Additional keyword arguments to be passed to the base class :class:`ProposalBasedSamplerNew`.
+        Additional keyword arguments to be passed to the base class 
+        :class:`ProposalBasedSamplerNew`.
 
     Example
     -------
@@ -52,8 +59,10 @@ class CWMHNew(ProposalBasedSamplerNew):
         # Logpdf function
         logpdf_func = lambda x: -1/(std**2)*np.sum((x-mu)**2)
 
-        # Define distribution from logpdf as UserDefinedDistribution (sample and gradients also supported as inputs to UserDefinedDistribution)
-        target = cuqi.distribution.UserDefinedDistribution(dim=dim, logpdf_func=logpdf_func)
+        # Define distribution from logpdf as UserDefinedDistribution (sample
+        # and gradients also supported as inputs to UserDefinedDistribution)
+        target = cuqi.distribution.UserDefinedDistribution(
+            dim=dim, logpdf_func=logpdf_func)
 
         # Set up sampler
         sampler = cuqi.experimental.mcmc.CWMHNew(target, scale=1)
@@ -121,7 +130,8 @@ class CWMHNew(ProposalBasedSamplerNew):
         x_star = self.current_point.copy()
         target_eval_t = self.current_target
         if isinstance(self.proposal,cuqi.distribution.Distribution):
-            x_i_star = self.proposal(location= self.current_point, scale = self.scale).sample()
+            x_i_star = self.proposal(
+                location= self.current_point, scale=self.scale).sample()
         else:
             x_i_star = self.proposal(self.current_point, self.scale) 
         acc = np.zeros(self.dim)

--- a/cuqi/experimental/mcmc/_cwmh.py
+++ b/cuqi/experimental/mcmc/_cwmh.py
@@ -60,7 +60,7 @@ class CWMHNew(ProposalBasedSamplerNew):
                          initial_point=initial_point, **kwargs)
         self._acc = [np.ones((self.dim))]
         self.scale = np.ones(self.dim)*scale
-        self._scale_old = np.ones(self.dim)*scale
+        self._scale_temp = np.ones(self.dim)*scale
 
     def validate_target(self):
         pass # All targets are valid
@@ -142,15 +142,15 @@ class CWMHNew(ProposalBasedSamplerNew):
         # compute new scaling parameter
         zeta = 1/np.sqrt(update_count+1)   # ensures that the variation of lambda(i) vanishes
         print('zeta:',zeta)
-        print('lambd[:, i]',self._scale_old)
+        print('lambd[:, i]',self._scale_temp)
         scale_temp = np.exp(
-            np.log(self._scale_old) + zeta*(hat_acc-star_acc))  
+            np.log(self._scale_temp) + zeta*(hat_acc-star_acc))
 
         # update parameters
         print('scale_temp:',scale_temp)
         self.scale = np.minimum(scale_temp, np.ones(self.dim))
         print('self.scale:',self.scale)
-        self._scale_old = scale_temp
+        self._scale_temp = scale_temp
 
     def get_state(self):
         return {'sampler_type': 'CWMH', 'current_point': self.current_point.to_numpy(), 'current_target': self.current_target, 'scale': self.scale}

--- a/cuqi/experimental/mcmc/_cwmh.py
+++ b/cuqi/experimental/mcmc/_cwmh.py
@@ -99,7 +99,9 @@ class CWMHNew(ProposalBasedSamplerNew):
     def validate_target(self):
         pass # All targets are valid
 
-    @ProposalBasedSamplerNew.proposal.setter 
+    @ProposalBasedSamplerNew.proposal.setter
+     # TODO. Check if we can refactor this.
+    # We can work with a validate_proposal method instead?
     def proposal(self, value):
         fail_msg = "Proposal should be either None, "+\
             f"{cuqi.distribution.Distribution.__class__.__name__} "+\

--- a/cuqi/experimental/mcmc/_cwmh.py
+++ b/cuqi/experimental/mcmc/_cwmh.py
@@ -136,8 +136,6 @@ class CWMHNew(ProposalBasedSamplerNew):
             raise ValueError(fail_msg)
 
     def step(self):
-        """ Perform one step of the sampler by transitioning the current point
-        to a new point according to the sampler's transition kernel. """
         # Propose state x_i_star used to update
         # each component of x_t step by step
         x_t = self.current_point.copy()
@@ -180,8 +178,6 @@ class CWMHNew(ProposalBasedSamplerNew):
         return acc
 
     def tune(self, skip_len, update_count):
-        """ Tune the parameters of the sampler. This method is called after each
-        step of the warmup phase. """
         idx = update_count
         star_acc = 0.21/self.dim + 0.23
         hat_acc = np.mean(self._acc[idx*skip_len:(idx+1)*skip_len], axis=0)
@@ -197,7 +193,6 @@ class CWMHNew(ProposalBasedSamplerNew):
         self._scale_temp = scale_temp
 
     def get_state(self):
-        """ Return the state of the sampler. """
         current_point = self.current_point
         if isinstance(current_point, CUQIarray):
             current_point = current_point.to_numpy()
@@ -208,7 +203,6 @@ class CWMHNew(ProposalBasedSamplerNew):
                 'scale': self.scale}
 
     def set_state(self, state):
-        """ Set the state of the sampler. """
         current_point = state['current_point']
         if not isinstance(current_point, CUQIarray):
             current_point = CUQIarray(current_point,

--- a/cuqi/experimental/mcmc/_sampler.py
+++ b/cuqi/experimental/mcmc/_sampler.py
@@ -238,7 +238,6 @@ class ProposalBasedSamplerNew(SamplerNew, ABC):
         self.current_target = self.target.logd(self.current_point)
         self.proposal = proposal
         self.scale = scale
-        self._scale_old = scale
 
         self._acc = [ 1 ] # TODO. Check
 

--- a/cuqi/experimental/mcmc/_sampler.py
+++ b/cuqi/experimental/mcmc/_sampler.py
@@ -238,6 +238,7 @@ class ProposalBasedSamplerNew(SamplerNew, ABC):
         self.current_target = self.target.logd(self.current_point)
         self.proposal = proposal
         self.scale = scale
+        self._scale_old = scale
 
         self._acc = [ 1 ] # TODO. Check
 

--- a/tests/experimental/test_mcmc.py
+++ b/tests/experimental/test_mcmc.py
@@ -14,12 +14,12 @@ def assert_true_if_sampling_is_equivalent(
     Nb: int
         Number of burn-in samples. (to be removed from the samples)
 
-    old_idx: list of int of length 2
+    old_idx: list of length 2
         Indexes to slice the samples from the old sampler. The first index is
         the index of the first sample to be compared and the second index is of
         the last sample.
 
-    new_idx: list of int of length 2
+    new_idx: list of length 2
         Indexes to slice the samples from the new sampler. The first index is
         the index of the first sample to be compared and the second index is of
         the last sample.
@@ -49,12 +49,12 @@ def assert_true_if_warmup_is_equivalent(
     strategy: str
         Tuning strategy defined by sampler to compare with. Default is MH.
 
-    old_idx: list of int of length 2
+    old_idx: list of length 2
         Indexes to slice the samples from the old sampler. The first index is
         the index of the first sample to be compared and the second index is of
         the last sample.
 
-    new_idx: list of int of length 2
+    new_idx: list of length 2
         Indexes to slice the samples from the new sampler. The first index is
         the index of the first sample to be compared (after burn-in is removed,
         i.e. samples start index is Nb+new_idx[0]) and the second index is of

--- a/tests/experimental/test_mcmc.py
+++ b/tests/experimental/test_mcmc.py
@@ -65,7 +65,7 @@ targets = [
 
 
 def assert_true_if_warmup_is_equivalent2(
-        sampler_old: cuqi.sampler.Sampler, sampler_new: cuqi.mcmc.SamplerNew):
+        sampler_old: cuqi.sampler.Sampler, sampler_new: cuqi.experimental.mcmc.SamplerNew):
     """ Assert that the samples from the old and new sampler are equivalent.
      
     Ns: int

--- a/tests/experimental/test_mcmc.py
+++ b/tests/experimental/test_mcmc.py
@@ -6,8 +6,24 @@ def assert_true_if_sampling_is_equivalent(
         sampler_old: cuqi.sampler.Sampler,
         sampler_new: cuqi.experimental.mcmc.SamplerNew,
         Ns=100, atol=1e-1, old_idx=[0, None], new_idx=[0, -1]):
-    """ Assert that the samples from the old and new sampler are equivalent. """
+    """ Assert that the samples from the old and new sampler are equivalent.
 
+    Ns: int
+        Number of samples.
+
+    Nb: int
+        Number of burn-in samples. (to be removed from the samples)
+
+    old_idx: list of int of length 2
+        Indexes to slice the samples from the old sampler. The first index is
+        the index of the first sample to be compared and the second index is of
+        the last sample.
+
+    new_idx: list of int of length 2
+        Indexes to slice the samples from the new sampler. The first index is
+        the index of the first sample to be compared and the second index is of
+        the last sample.
+    """
     np.random.seed(0)
     samples_old = sampler_old.sample(Ns).samples[..., old_idx[0]:old_idx[1]]
 
@@ -26,13 +42,23 @@ def assert_true_if_warmup_is_equivalent(
      
     Ns: int
         Number of samples.
-    
+
     Nb: int
         Number of burn-in samples. (to be removed from the samples)
 
     strategy: str
         Tuning strategy defined by sampler to compare with. Default is MH.
-              
+
+    old_idx: list of int of length 2
+        Indexes to slice the samples from the old sampler. The first index is
+        the index of the first sample to be compared and the second index is of
+        the last sample.
+
+    new_idx: list of int of length 2
+        Indexes to slice the samples from the new sampler. The first index is
+        the index of the first sample to be compared (after burn-in is removed,
+        i.e. samples start index is Nb+new_idx[0]) and the second index is of
+        the last sample.
     """
 
     if strategy == "MH_like":

--- a/tests/experimental/test_mcmc.py
+++ b/tests/experimental/test_mcmc.py
@@ -145,7 +145,7 @@ def test_CWMH_regression_sample(target: cuqi.density.Density):
     sampler_old = cuqi.sampler.CWMH(target,
                                     scale=np.ones(target.dim),
                                     x0=np.zeros(target.dim))
-    sampler_new = cuqi.mcmc.CWMHNew(target, scale=np.ones(target.dim),
+    sampler_new = cuqi.experimental.mcmc.CWMHNew(target, scale=np.ones(target.dim),
                                     initial_point=np.zeros(target.dim))
     assert_true_if_sampling_is_equivalent(sampler_old, sampler_new,
                                           Ns=10,
@@ -156,14 +156,14 @@ def test_CWMH_regression_sample(target: cuqi.density.Density):
 def test_CWMH_regression_warmup2(target: cuqi.density.Density):
     """Test the CWMH sampler regression."""
     sampler_old = cuqi.sampler.CWMH(target, scale=np.ones(target.dim))
-    sampler_new = cuqi.mcmc.CWMHNew(target, scale=np.ones(target.dim))
+    sampler_new = cuqi.experimental.mcmc.CWMHNew(target, scale=np.ones(target.dim))
     assert_true_if_warmup_is_equivalent2(sampler_old, sampler_new)
 
 @pytest.mark.parametrize("target", targets)
 def test_CWMH_regression_warmup(target: cuqi.density.Density):
     """Test the CWMH sampler regression."""
     sampler_old = cuqi.sampler.CWMH(target, scale=np.ones(target.dim))
-    sampler_new = cuqi.mcmc.CWMHNew(target, scale=np.ones(target.dim))
+    sampler_new = cuqi.experimental.mcmc.CWMHNew(target, scale=np.ones(target.dim))
     assert_true_if_warmup_is_equivalent(sampler_old, sampler_new,
                                         Ns=100,
                                         strategy="MH_like",

--- a/tests/experimental/test_mcmc.py
+++ b/tests/experimental/test_mcmc.py
@@ -60,6 +60,31 @@ targets = [
 ]
 """ List of targets to test against. """
 
+
+def assert_true_if_warmup_is_equivalent2(
+        sampler_old: cuqi.sampler.Sampler, sampler_new: cuqi.mcmc.SamplerNew):
+    """ Assert that the samples from the old and new sampler are equivalent.
+     
+    Ns: int
+        Number of samples.
+    
+    Nb: int
+        Number of burn-in samples. (to be removed from the samples)
+
+    Na: int
+        Number of iterations to adapt.
+              
+    """
+
+    np.random.seed(0)
+    sampler_old.sample_adapt(N=101)
+
+    np.random.seed(0)
+    sampler_new.warmup(100)
+    
+
+    assert np.allclose(sampler_old.scale, sampler_new.scale)
+
 # ============ MH ============
 
 @pytest.mark.parametrize("target", targets)
@@ -124,17 +149,12 @@ def test_CWMH_regression_sample(target: cuqi.density.Density):
                                           old_idx=[0, -1],
                                           new_idx=[1, -1])
 
-# skip this tests for now
-@pytest.mark.skip(reason="The warmup is not verified yet for CWMH sampler.")
 @pytest.mark.parametrize("target", targets)
-def test_CWMH_regression_warmup(target: cuqi.density.Density):
+def test_CWMH_regression_warmup2(target: cuqi.density.Density):
     """Test the CWMH sampler regression."""
     sampler_old = cuqi.sampler.CWMH(target, scale=np.ones(target.dim))
     sampler_new = cuqi.mcmc.CWMHNew(target, scale=np.ones(target.dim))
-    assert_true_if_warmup_is_equivalent(sampler_old, sampler_new,
-                                        Ns=10,
-                                        old_idx=[0, None],
-                                        new_idx=[0, -1])
+    assert_true_if_warmup_is_equivalent2(sampler_old, sampler_new)
 
 # ============ Checkpointing ============
 


### PR DESCRIPTION
closes #371 

Things to consider for the review:
- The code is mainly copied from the original `CWMH`
- Modification to remove all the outer sampling loops and just keep the step and tune parts
- I needed to introduce additional scale parameter to keep track of old scale (to enable matching the old and new sampler)
- I modified the class documentation a bit, including stating that scale can be an array in this CWMH case. And updated the example code in the class documentation
-  I modified the tests method `assert_true_if_sampling_is_equivalent` and `assert_true_if_warmup_is_equivalent` to accept additional inputs: `old_idx` and `new_idx`. Which I use for example to remove first sample in the new sampler which is the initial point, that is not included in the samples of the old sampler. I use it also to remove the last sample in the old sampler because it is repeated (same as second to last sample)

Question:
- [x] I am not sure about the dim property? it seems like it was remover from the `NewSampler`. Should we still support it?(I removed dim from CWMH as discussed)