### PR TITLE
Implement get_state, set_state, get_history, set_history in base class.

### DIFF
--- a/cuqi/experimental/mcmc/_cwmh.py
+++ b/cuqi/experimental/mcmc/_cwmh.py
@@ -144,7 +144,7 @@ class CWMHNew(ProposalBasedSamplerNew):
 
         # Propose a sample x_all_components from the proposal distribution
         # for all the components
-        target_eval_t = self.current_target
+        target_eval_t = self.current_target_logd
         if isinstance(self.proposal,cuqi.distribution.Distribution):
             x_all_components = self.proposal(
                 location= self.current_point, scale=self.scale).sample()
@@ -175,7 +175,7 @@ class CWMHNew(ProposalBasedSamplerNew):
 
             x_star = x_t.copy()
 
-        self.current_target = target_eval_t
+        self.current_target_logd = target_eval_t
         self.current_point = x_t
 
         return acc
@@ -207,7 +207,7 @@ class CWMHNew(ProposalBasedSamplerNew):
 
         return {'sampler_type': 'CWMH',
                 'current_point': current_point,
-                'current_target': self.current_target,
+                'current_target': self.current_target_logd,
                 'scale': self.scale}
 
     def set_state(self, state):
@@ -217,5 +217,5 @@ class CWMHNew(ProposalBasedSamplerNew):
                                       geometry=self.target.geometry)
 
         self.current_point = current_point
-        self.current_target = state['current_target']
+        self.current_target_logd = state['current_target']
         self.scale = state['scale']

--- a/cuqi/experimental/mcmc/_cwmh.py
+++ b/cuqi/experimental/mcmc/_cwmh.py
@@ -199,23 +199,3 @@ class CWMHNew(ProposalBasedSamplerNew):
         # Update the scale parameter
         self.scale = np.minimum(scale_temp, np.ones(self.dim))
         self._scale_temp = scale_temp
-
-    def get_state(self):
-        current_point = self.current_point
-        if isinstance(current_point, CUQIarray):
-            current_point = current_point.to_numpy()
-
-        return {'sampler_type': 'CWMH',
-                'current_point': current_point,
-                'current_target': self.current_target_logd,
-                'scale': self.scale}
-
-    def set_state(self, state):
-        current_point = state['current_point']
-        if not isinstance(current_point, CUQIarray):
-            current_point = CUQIarray(current_point,
-                                      geometry=self.target.geometry)
-
-        self.current_point = current_point
-        self.current_target_logd = state['current_target']
-        self.scale = state['scale']

--- a/cuqi/experimental/mcmc/_langevin_algorithm.py
+++ b/cuqi/experimental/mcmc/_langevin_algorithm.py
@@ -61,7 +61,7 @@ class ULANew(SamplerNew): # Refactor to Proposal-based sampler?
     # TODO: update demo once sampler merged
     """
 
-    _STATE_KEYS = SamplerNew._STATE_KEYS + ['scale', 'current_target_grad']
+    _STATE_KEYS = SamplerNew._STATE_KEYS.union({'scale', 'current_target_grad'})
 
     def __init__(self, target, scale=1.0, **kwargs):
 

--- a/cuqi/experimental/mcmc/_langevin_algorithm.py
+++ b/cuqi/experimental/mcmc/_langevin_algorithm.py
@@ -60,14 +60,17 @@ class ULANew(SamplerNew): # Refactor to Proposal-based sampler?
     A Deblur example can be found in demos/demo27_ULA.py
     # TODO: update demo once sampler merged
     """
+
+    _STATE_KEYS = SamplerNew._STATE_KEYS + ['scale', 'current_target_grad']
+
     def __init__(self, target, scale=1.0, **kwargs):
 
         super().__init__(target, **kwargs)
 
         self.scale = scale
         self.current_point = self.initial_point
-        self.current_target_eval = self.target.logd(self.current_point)
-        self.current_target_grad_eval = self.target.gradient(self.current_point)
+        self.current_target_logd = self.target.logd(self.current_point)
+        self.current_target_grad = self.target.gradient(self.current_point)
         self._acc = [1] # TODO. Check if we need this
 
     def validate_target(self):
@@ -99,15 +102,15 @@ class ULANew(SamplerNew): # Refactor to Proposal-based sampler?
             1 (accepted)
         """
         self.current_point = x_star
-        self.current_target_eval = target_eval_star
-        self.current_target_grad_eval = target_grad_star
+        self.current_target_logd = target_eval_star
+        self.current_target_grad = target_grad_star
         acc = 1
         return acc
 
     def step(self):
         # propose state
         xi = cuqi.distribution.Normal(mean=np.zeros(self.dim), std=np.sqrt(self.scale)).sample()
-        x_star = self.current_point + 0.5*self.scale*self.current_target_grad_eval + xi
+        x_star = self.current_point + 0.5*self.scale*self.current_target_grad + xi
 
         # evaluate target
         target_eval_star, target_grad_star = self.target.logd(x_star), self.target.gradient(x_star)
@@ -120,26 +123,6 @@ class ULANew(SamplerNew): # Refactor to Proposal-based sampler?
     def tune(self, skip_len, update_count):
         pass
 
-    def get_state(self):
-        if isinstance(self.current_point, CUQIarray):
-            self.current_point = self.current_point.to_numpy()
-        if isinstance(self.current_target_eval, CUQIarray):
-            self.current_target_eval = self.current_target_eval.to_numpy()
-        if isinstance(self.current_target_grad_eval, CUQIarray):
-            self.current_target_grad_eval = self.current_target_grad_eval.to_numpy()
-        return {'sampler_type': 'ULA', 'current_point': self.current_point, \
-                'current_target_eval': self.current_target_eval, \
-                'current_target_grad_eval': self.current_target_grad_eval, \
-                'scale': self.scale}
-
-    def set_state(self, state):
-        temp = CUQIarray(state['current_point'] , geometry=self.target.geometry)
-        self.current_point = temp
-        temp = CUQIarray(state['current_target_eval'] , geometry=self.target.geometry)
-        self.current_target_eval = temp
-        temp = CUQIarray(state['current_target_grad_eval'] , geometry=self.target.geometry)
-        self.current_target_grad_eval = temp
-        self.scale = state['scale']
 
 class MALANew(ULANew): # Refactor to Proposal-based sampler?
     """  Metropolis-adjusted Langevin algorithm (MALA) (Roberts and Tweedie, 1996)
@@ -241,15 +224,3 @@ class MALANew(ULANew): # Refactor to Proposal-based sampler?
         mu = theta_k + ((self.scale)/2)*g_logpi_k
         misfit = theta_star - mu
         return -0.5*((1/(self.scale))*(misfit.T @ misfit))
-
-    def get_state(self):
-        if isinstance(self.current_point, CUQIarray):
-            self.current_point = self.current_point.to_numpy()
-        if isinstance(self.current_target_eval, CUQIarray):
-            self.current_target_eval = self.current_target_eval.to_numpy()
-        if isinstance(self.current_target_grad_eval, CUQIarray):
-            self.current_target_grad_eval = self.current_target_grad_eval.to_numpy()
-        return {'sampler_type': 'MALA', 'current_point': self.current_point, \
-                'current_target_eval': self.current_target_eval, \
-                'current_target_grad_eval': self.current_target_grad_eval, \
-                'scale': self.scale}

--- a/cuqi/experimental/mcmc/_langevin_algorithm.py
+++ b/cuqi/experimental/mcmc/_langevin_algorithm.py
@@ -61,7 +61,7 @@ class ULANew(SamplerNew): # Refactor to Proposal-based sampler?
     # TODO: update demo once sampler merged
     """
 
-    _STATE_KEYS = SamplerNew._STATE_KEYS.union({'scale', 'current_target_grad'})
+    _STATE_KEYS = SamplerNew._STATE_KEYS.union({'current_target_logd', 'scale', 'current_target_grad'})
 
     def __init__(self, target, scale=1.0, **kwargs):
 

--- a/cuqi/experimental/mcmc/_langevin_algorithm.py
+++ b/cuqi/experimental/mcmc/_langevin_algorithm.py
@@ -202,9 +202,9 @@ class MALANew(ULANew): # Refactor to Proposal-based sampler?
         scaler
             1 if accepted, 0 otherwise
         """
-        log_target_ratio = target_eval_star - self.current_target_eval
+        log_target_ratio = target_eval_star - self.current_target_logd
         log_prop_ratio = self._log_proposal(self.current_point, x_star, target_grad_star) \
-            - self._log_proposal(x_star, self.current_point,  self.current_target_grad_eval)
+            - self._log_proposal(x_star, self.current_point,  self.current_target_grad)
         log_alpha = min(0, log_target_ratio + log_prop_ratio)
 
         # accept/reject with Metropolis
@@ -212,8 +212,8 @@ class MALANew(ULANew): # Refactor to Proposal-based sampler?
         log_u = np.log(np.random.rand())
         if (log_u <= log_alpha) and (np.isnan(target_eval_star) == False):
             self.current_point = x_star
-            self.current_target_eval = target_eval_star
-            self.current_target_grad_eval = target_grad_star
+            self.current_target_logd = target_eval_star
+            self.current_target_grad = target_grad_star
             acc = 1
         return acc
 

--- a/cuqi/experimental/mcmc/_mh.py
+++ b/cuqi/experimental/mcmc/_mh.py
@@ -23,6 +23,8 @@ class MHNew(ProposalBasedSamplerNew):
 
     """
 
+    _STATE_KEYS = ProposalBasedSamplerNew._STATE_KEYS + ['_scale_temp']
+
     def __init__(self, target, proposal=None, scale=1, **kwargs):
         super().__init__(target, proposal=proposal, scale=scale, **kwargs)
         # Due to a bug? in old MH, we must keep track of this extra variable to match behavior.
@@ -79,13 +81,3 @@ class MHNew(ProposalBasedSamplerNew):
 
         # update parameters
         self.scale = min(self._scale_temp, 1)
-
-    def get_state(self):
-        return {'sampler_type': 'MH', 'current_point': self.current_point.to_numpy(), 'current_target': self.current_target.to_numpy(), 'scale': self.scale}
-
-    def set_state(self, state):
-        temp = CUQIarray(state['current_point'] , geometry=self.target.geometry)
-        self.current_point = temp
-        temp = CUQIarray(state['current_target'] , geometry=self.target.geometry)
-        self.current_target = temp
-        self.scale = state['scale']

--- a/cuqi/experimental/mcmc/_mh.py
+++ b/cuqi/experimental/mcmc/_mh.py
@@ -23,7 +23,7 @@ class MHNew(ProposalBasedSamplerNew):
 
     """
 
-    _STATE_KEYS = ProposalBasedSamplerNew._STATE_KEYS + ['scale', '_scale_temp']
+    _STATE_KEYS = ProposalBasedSamplerNew._STATE_KEYS.union({'scale', '_scale_temp'})
 
     def __init__(self, target, proposal=None, scale=1, **kwargs):
         super().__init__(target, proposal=proposal, scale=scale, **kwargs)

--- a/cuqi/experimental/mcmc/_mh.py
+++ b/cuqi/experimental/mcmc/_mh.py
@@ -56,7 +56,7 @@ class MHNew(ProposalBasedSamplerNew):
         target_eval_star = self.target.logd(x_star)
 
         # ratio and acceptance probability
-        ratio = target_eval_star - self.current_target # proposal is symmetric
+        ratio = target_eval_star - self.current_target_logd # proposal is symmetric
         alpha = min(0, ratio)
 
         # accept/reject
@@ -64,7 +64,7 @@ class MHNew(ProposalBasedSamplerNew):
         acc = 0
         if (u_theta <= alpha):
             self.current_point = x_star
-            self.current_target = target_eval_star
+            self.current_target_logd = target_eval_star
             acc = 1
         
         return acc

--- a/cuqi/experimental/mcmc/_mh.py
+++ b/cuqi/experimental/mcmc/_mh.py
@@ -23,7 +23,7 @@ class MHNew(ProposalBasedSamplerNew):
 
     """
 
-    _STATE_KEYS = ProposalBasedSamplerNew._STATE_KEYS + ['_scale_temp']
+    _STATE_KEYS = ProposalBasedSamplerNew._STATE_KEYS + ['scale', '_scale_temp']
 
     def __init__(self, target, proposal=None, scale=1, **kwargs):
         super().__init__(target, proposal=proposal, scale=scale, **kwargs)

--- a/cuqi/experimental/mcmc/_pcn.py
+++ b/cuqi/experimental/mcmc/_pcn.py
@@ -5,7 +5,7 @@ from cuqi.array import CUQIarray
 
 class pCNNew(SamplerNew):  # Refactor to Proposal-based sampler?
 
-    _STATE_KEYS = SamplerNew._STATE_KEYS + ['scale', 'current_likelihood_logd']
+    _STATE_KEYS = SamplerNew._STATE_KEYS.union({'scale', 'current_likelihood_logd'})
 
     def __init__(self, target, scale=1.0, **kwargs):
 

--- a/cuqi/experimental/mcmc/_pcn.py
+++ b/cuqi/experimental/mcmc/_pcn.py
@@ -5,7 +5,7 @@ from cuqi.array import CUQIarray
 
 class pCNNew(SamplerNew):  # Refactor to Proposal-based sampler?
 
-    _STATE_KEYS = SamplerNew._STATE_KEYS + ['scale', 'current_loglike_logd']
+    _STATE_KEYS = SamplerNew._STATE_KEYS + ['scale', 'current_likelihood_logd']
 
     def __init__(self, target, scale=1.0, **kwargs):
 
@@ -13,7 +13,7 @@ class pCNNew(SamplerNew):  # Refactor to Proposal-based sampler?
 
         self.scale = scale
         self.current_point = self.initial_point
-        self.current_loglike_logd = self._loglikelihood(self.current_point)
+        self.current_likelihood_logd = self._loglikelihood(self.current_point)
 
         self._acc = [1] # TODO. Check if we need this
 
@@ -35,7 +35,7 @@ class pCNNew(SamplerNew):  # Refactor to Proposal-based sampler?
         loglike_eval_star =  self._loglikelihood(x_star) 
 
         # ratio and acceptance probability
-        ratio = loglike_eval_star - self.current_loglike_logd  # proposal is symmetric
+        ratio = loglike_eval_star - self.current_likelihood_logd  # proposal is symmetric
         alpha = min(0, ratio)
 
         # accept/reject
@@ -43,7 +43,7 @@ class pCNNew(SamplerNew):  # Refactor to Proposal-based sampler?
         u_theta = np.log(np.random.rand())
         if (u_theta <= alpha):
             self.current_point = x_star
-            self.current_loglike_logd = loglike_eval_star
+            self.current_likelihood_logd = loglike_eval_star
             acc = 1
         
         return acc

--- a/cuqi/experimental/mcmc/_rto.py
+++ b/cuqi/experimental/mcmc/_rto.py
@@ -50,6 +50,7 @@ class LinearRTONew(SamplerNew):
 
         if initial_point is None: #TODO: Replace later with a getter
             self.initial_point = np.zeros(self.dim)
+            self._samples = [self.initial_point]
 
         self.current_point = self.initial_point
         self._acc = [1] # TODO. Check if we need this

--- a/cuqi/experimental/mcmc/_rto.py
+++ b/cuqi/experimental/mcmc/_rto.py
@@ -189,12 +189,6 @@ class LinearRTONew(SamplerNew):
         if not hasattr(self.prior, "sqrtprecTimesMean"):
             raise TypeError("Prior must contain a sqrtprecTimesMean attribute")
 
-    def get_state(self): #TODO: LinearRTO only need initial_point for reproducibility?
-        return {'sampler_type': 'LinearRTO'}
-
-    def set_state(self, state): #TODO: LinearRTO only need initial_point for reproducibility?
-        pass
-
 class RegularizedLinearRTONew(LinearRTONew):
     """
     Regularized Linear RTO (Randomize-Then-Optimize) sampler.

--- a/cuqi/experimental/mcmc/_sampler.py
+++ b/cuqi/experimental/mcmc/_sampler.py
@@ -293,7 +293,7 @@ class SamplerNew(ABC):
 class ProposalBasedSamplerNew(SamplerNew, ABC):
     """ Abstract base class for samplers that use a proposal distribution. """
 
-    _STATE_KEYS = SamplerNew._STATE_KEYS + ['proposal', 'scale']
+    _STATE_KEYS = SamplerNew._STATE_KEYS + ['scale']
 
     def __init__(self, target, proposal=None, scale=1, **kwargs):
         """ Initializer for proposal based samplers. 

--- a/cuqi/experimental/mcmc/_sampler.py
+++ b/cuqi/experimental/mcmc/_sampler.py
@@ -22,7 +22,7 @@ class SamplerNew(ABC):
 
     """
 
-    _STATE_KEYS = ['current_point', 'current_target']
+    _STATE_KEYS = ['current_point', 'current_target_logd']
     """ List of keys for the state dictionary. """
 
     _HISTORY_KEYS = ['_samples', '_acc']
@@ -95,6 +95,25 @@ class SamplerNew(ABC):
         self._target = value
         self.validate_target()
 
+    @property
+    def current_point(self):
+        """ The current point of the sampler. """
+        return self._current_point
+    
+    @current_point.setter
+    def current_point(self, value):
+        """ Set the current point of the sampler. """
+        self._current_point = value
+
+    @property
+    def current_target_logd(self):
+        """ The current target value of the sampler. """
+        return self._current_target_logd
+    
+    @current_target_logd.setter
+    def current_target_logd(self, value):
+        """ Set the current target value of the sampler. """
+        self._current_target_logd = value
 
     # ------------ Public methods ------------
 
@@ -277,7 +296,7 @@ class ProposalBasedSamplerNew(SamplerNew, ABC):
         super().__init__(target, **kwargs)
 
         self.current_point = self.initial_point
-        self.current_target = self.target.logd(self.current_point)
+        self.current_target_logd = self.target.logd(self.current_point)
         self.proposal = proposal
         self.scale = scale
 

--- a/cuqi/experimental/mcmc/_sampler.py
+++ b/cuqi/experimental/mcmc/_sampler.py
@@ -53,7 +53,7 @@ class SamplerNew(ABC):
 
         self.initial_point = initial_point
         
-        self._samples = [initial_point] # Remove?
+        self._samples = [initial_point] # Remove. See #324.
 
     # ------------ Abstract methods to be implemented by subclasses ------------
     

--- a/cuqi/experimental/mcmc/_sampler.py
+++ b/cuqi/experimental/mcmc/_sampler.py
@@ -13,6 +13,24 @@ except ImportError:
         warnings.warn("Module mcmc: Progressbar not found. Install progressbar2 to get sampling progress.")
         return iterable
 
+class _UniqueList(list):
+    """ Utility class to store a list of unique elements. """
+
+    def append(self, item):
+        """ Append an item to the list if it is not already in the list. """
+        if item not in self:
+            super().append(item)
+
+    def __add__(self, other):
+        """Override the + operator to ensure only unique elements are added."""
+        return _UniqueList(dict.fromkeys(self + other))
+    
+    def __iadd__(self, other):
+        """Override the += operator to ensure only unique elements are added."""
+        for item in other:
+            self.append(item)
+        return self
+
 class SamplerNew(ABC):
     """ Abstract base class for all samplers.
     
@@ -22,10 +40,10 @@ class SamplerNew(ABC):
 
     """
 
-    _STATE_KEYS = ['current_point', 'current_target_logd']
+    _STATE_KEYS = _UniqueList(['current_point', 'current_target_logd'])
     """ List of keys for the state dictionary. """
 
-    _HISTORY_KEYS = ['_samples', '_acc']
+    _HISTORY_KEYS = _UniqueList(['_samples', '_acc'])
     """ List of keys for the history dictionary. """
 
     def __init__(self, target: cuqi.density.Density, initial_point=None, callback=None):

--- a/cuqi/experimental/mcmc/_sampler.py
+++ b/cuqi/experimental/mcmc/_sampler.py
@@ -23,7 +23,10 @@ class _UniqueList(list):
 
     def __add__(self, other):
         """Override the + operator to ensure only unique elements are added."""
-        return _UniqueList(dict.fromkeys(self + other))
+        new_list = _UniqueList(self)
+        for item in other:
+            new_list.append(item)
+        return new_list
     
     def __iadd__(self, other):
         """Override the += operator to ensure only unique elements are added."""

--- a/cuqi/experimental/mcmc/_sampler.py
+++ b/cuqi/experimental/mcmc/_sampler.py
@@ -205,7 +205,28 @@ class SamplerNew(ABC):
         return self
     
     def get_state(self) -> dict:
-        """ Return the state of the sampler. """   
+        """ Return the state of the sampler. 
+
+        The state is used when checkpointing the sampler.
+
+        The state of the sampler is a dictionary with keys 'metadata' and 'state'.
+        The 'metadata' key contains information about the sampler type.
+        The 'state' key contains the state of the sampler.
+
+        For example, the state of a "MH" sampler could be:
+
+        state = {
+            'metadata': {
+                'sampler_type': 'MH'
+            },
+            'state': {
+                'current_point': np.array([...]),
+                'current_target_logd': -123.45,
+                'scale': 1.0,
+                ...
+            }
+        }
+        """   
         state = {
             'metadata': {
                 'sampler_type': self.__class__.__name__
@@ -217,7 +238,26 @@ class SamplerNew(ABC):
         return state
 
     def set_state(self, state: dict):
-        """ Set the state of the sampler. """
+        """ Set the state of the sampler.
+
+        The state is used when loading the sampler from a checkpoint.
+
+        The state of the sampler is a dictionary with keys 'metadata' and 'state'.
+
+        For example, the state of a "MH" sampler could be:
+
+        state = {
+            'metadata': {
+                'sampler_type': 'MH'
+            },
+            'state': {
+                'current_point': np.array([...]),
+                'current_target_logd': -123.45,
+                'scale': 1.0,
+                ...
+            }
+        }
+        """
         if state['metadata']['sampler_type'] != self.__class__.__name__:
             raise ValueError(f"Sampler type in state dictionary ({state['metadata']['sampler_type']}) does not match the type of the sampler ({self.__class__.__name__}).")
         

--- a/cuqi/experimental/mcmc/_sampler.py
+++ b/cuqi/experimental/mcmc/_sampler.py
@@ -22,6 +22,12 @@ class SamplerNew(ABC):
 
     """
 
+    _STATE_KEYS = ['current_point', 'current_target']
+    """ List of keys for the state dictionary. """
+
+    _HISTORY_KEYS = ['_samples', '_acc']
+    """ List of keys for the history dictionary. """
+
     def __init__(self, target: cuqi.density.Density, initial_point=None, callback=None):
         """ Initializer for abstract base class for all samplers.
         
@@ -45,8 +51,10 @@ class SamplerNew(ABC):
         # Choose initial point if not given
         if initial_point is None:
             initial_point = np.ones(self.dim)
+
+        self.initial_point = initial_point
         
-        self._samples = [initial_point]
+        self._samples = [initial_point] # Remove?
 
     # ------------ Abstract methods to be implemented by subclasses ------------
     
@@ -65,29 +73,7 @@ class SamplerNew(ABC):
         """ Validate the target is compatible with the sampler. Called when the target is set. Should raise an error if the target is not compatible. """
         pass
 
-    @abstractmethod
-    def get_state(self):
-        """ Return the state of the sampler. """
-        pass
-
-    @abstractmethod
-    def set_state(self, state):
-        """ Set the state of the sampler. """
-        pass
-
-
     # ------------ Public attributes ------------
-
-    @property
-    def initial_point(self):
-        """ Return the initial point of the sampler. This is always the first sample. """
-        return self._samples[0]
-    
-    @initial_point.setter
-    def initial_point(self, value):
-        """ Set the initial point of the sampler. """
-        self._samples[0] = value
-    
     @property
     def dim(self):
         """ Dimension of the target density. """
@@ -209,6 +195,54 @@ class SamplerNew(ABC):
             self._call_callback(self.current_point, len(self._samples)-1)
 
         return self
+    
+    def get_state(self) -> dict:
+        """ Return the state of the sampler. """   
+        state = {
+            'metadata': {
+                'sampler_type': self.__class__.__name__
+            },
+            'state': {
+                key: getattr(self, key) for key in self._STATE_KEYS
+            }
+        }
+        return state
+
+    def set_state(self, state: dict):
+        """ Set the state of the sampler. """
+        if state['metadata']['sampler_type'] != self.__class__.__name__:
+            raise ValueError(f"Sampler type in state dictionary ({state['metadata']['sampler_type']}) does not match the type of the sampler ({self.__class__.__name__}).")
+        
+        for key, value in state['state'].items():
+            if key in self._STATE_KEYS:
+                setattr(self, key, value)
+            else:
+                raise ValueError(f"Key {key} not recognized in state dictionary of sampler {self.__class__.__name__}.")
+            
+    def get_history(self) -> dict:
+        """ Return the history of the sampler. """
+        history = {
+            'metadata': {
+                'sampler_type': self.__class__.__name__
+            },
+            'history': {
+                key: getattr(self, key) for key in self._HISTORY_KEYS
+            }
+        }
+        return history
+    
+    def set_history(self, history: dict):
+        """ Set the history of the sampler. """
+        if history['metadata']['sampler_type'] != self.__class__.__name__:
+            raise ValueError(f"Sampler type in history dictionary ({history['metadata']['sampler_type']}) does not match the type of the sampler ({self.__class__.__name__}).")
+        
+        for key, value in history['history'].items():
+            if key in self._HISTORY_KEYS:
+                setattr(self, key, value)
+            else:
+                raise ValueError(f"Key {key} not recognized in history dictionary of sampler {self.__class__.__name__}.")
+
+    # ------------ Private methods ------------
 
     def _call_callback(self, sample, sample_index):
         """ Calls the callback function. Assumes input is sample and sample index"""
@@ -218,6 +252,9 @@ class SamplerNew(ABC):
 
 class ProposalBasedSamplerNew(SamplerNew, ABC):
     """ Abstract base class for samplers that use a proposal distribution. """
+
+    _STATE_KEYS = SamplerNew._STATE_KEYS + ['proposal', 'scale']
+
     def __init__(self, target, proposal=None, scale=1, **kwargs):
         """ Initializer for proposal based samplers. 
 

--- a/cuqi/experimental/mcmc/_sampler.py
+++ b/cuqi/experimental/mcmc/_sampler.py
@@ -13,27 +13,6 @@ except ImportError:
         warnings.warn("Module mcmc: Progressbar not found. Install progressbar2 to get sampling progress.")
         return iterable
 
-class _UniqueList(list):
-    """ Utility class to store a list of unique elements. """
-
-    def append(self, item):
-        """ Append an item to the list if it is not already in the list. """
-        if item not in self:
-            super().append(item)
-
-    def __add__(self, other):
-        """Override the + operator to ensure only unique elements are added."""
-        new_list = _UniqueList(self)
-        for item in other:
-            new_list.append(item)
-        return new_list
-    
-    def __iadd__(self, other):
-        """Override the += operator to ensure only unique elements are added."""
-        for item in other:
-            self.append(item)
-        return self
-
 class SamplerNew(ABC):
     """ Abstract base class for all samplers.
     
@@ -42,12 +21,11 @@ class SamplerNew(ABC):
     Samples are stored in a list to allow for dynamic growth of the sample set. Returning samples is done by creating a new Samples object from the list of samples.
 
     """
+    _STATE_KEYS = {'current_point', 'current_target_logd'}
+    """ Set of keys for the state dictionary. """
 
-    _STATE_KEYS = _UniqueList(['current_point', 'current_target_logd'])
-    """ List of keys for the state dictionary. """
-
-    _HISTORY_KEYS = _UniqueList(['_samples', '_acc'])
-    """ List of keys for the history dictionary. """
+    _HISTORY_KEYS = {'_samples', '_acc'}
+    """ Set of keys for the history dictionary. """
 
     def __init__(self, target: cuqi.density.Density, initial_point=None, callback=None):
         """ Initializer for abstract base class for all samplers.
@@ -293,7 +271,7 @@ class SamplerNew(ABC):
 class ProposalBasedSamplerNew(SamplerNew, ABC):
     """ Abstract base class for samplers that use a proposal distribution. """
 
-    _STATE_KEYS = SamplerNew._STATE_KEYS + ['scale']
+    _STATE_KEYS = SamplerNew._STATE_KEYS.union({'scale'})
 
     def __init__(self, target, proposal=None, scale=1, **kwargs):
         """ Initializer for proposal based samplers. 

--- a/cuqi/experimental/mcmc/_sampler.py
+++ b/cuqi/experimental/mcmc/_sampler.py
@@ -21,7 +21,7 @@ class SamplerNew(ABC):
     Samples are stored in a list to allow for dynamic growth of the sample set. Returning samples is done by creating a new Samples object from the list of samples.
 
     """
-    _STATE_KEYS = {'current_point', 'current_target_logd'}
+    _STATE_KEYS = {'current_point'}
     """ Set of keys for the state dictionary. """
 
     _HISTORY_KEYS = {'_samples', '_acc'}
@@ -103,16 +103,6 @@ class SamplerNew(ABC):
     def current_point(self, value):
         """ Set the current point of the sampler. """
         self._current_point = value
-
-    @property
-    def current_target_logd(self):
-        """ The current target value of the sampler. """
-        return self._current_target_logd
-    
-    @current_target_logd.setter
-    def current_target_logd(self, value):
-        """ Set the current target value of the sampler. """
-        self._current_target_logd = value
 
     # ------------ Public methods ------------
 
@@ -271,7 +261,7 @@ class SamplerNew(ABC):
 class ProposalBasedSamplerNew(SamplerNew, ABC):
     """ Abstract base class for samplers that use a proposal distribution. """
 
-    _STATE_KEYS = SamplerNew._STATE_KEYS.union({'scale'})
+    _STATE_KEYS = SamplerNew._STATE_KEYS.union({'current_target_logd', 'scale'})
 
     def __init__(self, target, proposal=None, scale=1, **kwargs):
         """ Initializer for proposal based samplers. 

--- a/demos/demo36_experimental_mcmc_module.py
+++ b/demos/demo36_experimental_mcmc_module.py
@@ -52,9 +52,40 @@ print(f"Shape: {samples.shape}")
 samples.burnthin(1401).plot_pair()
 
 # %%
+# Getting sampler state or history
+#
+# The sampler state can be accessed as follows:
+
+state = sampler.get_state()
+
+# Sampler state is a dictionary with keys:
+print(state.keys())
+
+
+# %%
+# The key 'state' contains the actual state, while 'metadata' contains metadata e.g. sampler name.
+# To get the current point one does:
+print(state['state']['current_point'])
+
+# %%
+# Setting sampler state
+#
+# The sampler state can be set as follows:
+
+new_state = sampler.get_state()
+
+# Change current point
+new_state['state']['current_point'] = new_state['state']['current_point'] + 1
+
+# Set new state
+sampler.set_state(state)
+
+# %%
 # Checkpointing
 #
-# The new sampler supports checkpointing by saving and loading state (not samples) For example:
+# The new sampler supports checkpointing by saving and loading state (not samples).
+# Checkpoint uses the set_state and get_state methods to save and load state and then pickles the state. 
+# For example:
 
 # Save current state of sampler (e.g. current point, current scale etc.)
 sampler.save_checkpoint('demo36_sampler_checkpoint.pickle')

--- a/tests/zexperimental/test_mcmc.py
+++ b/tests/zexperimental/test_mcmc.py
@@ -342,10 +342,12 @@ def test_checkpointing(sampler: cuqi.experimental.mcmc.SamplerNew):
 
 state_history_targets = [
     cuqi.experimental.mcmc.MHNew(cuqi.testproblem.Deconvolution1D(dim=10).posterior, scale=0.5),
-    cuqi.experimental.mcmc.pCNNew(cuqi.testproblem.Deconvolution1D(dim=10).posterior, scale=0.5),
+    cuqi.experimental.mcmc.pCNNew(cuqi.testproblem.Deconvolution1D(dim=10).posterior, scale=0.001),
     cuqi.experimental.mcmc.CWMHNew(cuqi.testproblem.Deconvolution1D(dim=10).posterior, scale=0.5),
     cuqi.experimental.mcmc.ULANew(cuqi.testproblem.Deconvolution1D(dim=10).posterior, scale=0.0001),
     cuqi.experimental.mcmc.MALANew(cuqi.testproblem.Deconvolution1D(dim=10).posterior, scale=0.0001),
+    cuqi.experimental.mcmc.LinearRTONew(cuqi.testproblem.Deconvolution1D(dim=10).posterior),
+    cuqi.experimental.mcmc.RegularizedLinearRTONew(create_regularized_target(dim=10), stepsize=0.0001),
 ]
 
 

--- a/tests/zexperimental/test_mcmc.py
+++ b/tests/zexperimental/test_mcmc.py
@@ -293,7 +293,7 @@ def test_ensure_all_not_skipped_samplers_are_tested_for_checkpointing():
         if cls not in skip_checkpoint  # use cls here, not name
     ]
 
-    # Convert instances to their classes
+    # Convert instances in checkpoint_targets to their classes
     checkpoint_target_classes = [type(sampler) for sampler in checkpoint_targets]  
 
     # Convert 'samplers' classes to names for easier comparison and error reading

--- a/tests/zexperimental/test_mcmc.py
+++ b/tests/zexperimental/test_mcmc.py
@@ -272,6 +272,7 @@ def test_CWMH_regression_warmup(target: cuqi.density.Density):
 checkpoint_targets = [
     cuqi.experimental.mcmc.ULANew(cuqi.testproblem.Deconvolution1D().posterior, scale=0.0001),
     cuqi.experimental.mcmc.MALANew(cuqi.testproblem.Deconvolution1D().posterior, scale=0.0001),
+    cuqi.experimental.mcmc.LinearRTONew(cuqi.testproblem.Deconvolution1D().posterior),
 ]
     
 # List of samplers from cuqi.experimental.mcmc that should be skipped for checkpoint testing
@@ -280,7 +281,8 @@ skip_checkpoint = [
     cuqi.experimental.mcmc.ProposalBasedSamplerNew,
     cuqi.experimental.mcmc.MHNew,
     cuqi.experimental.mcmc.pCNNew,
-    cuqi.experimental.mcmc.CWMHNew
+    cuqi.experimental.mcmc.CWMHNew,
+    cuqi.experimental.mcmc.RegularizedLinearRTONew, # Due to the _choose_stepsize method
 ]
 
 def test_ensure_all_not_skipped_samplers_are_tested_for_checkpointing():


### PR DESCRIPTION
As described in #402 this PR seeks to implement get_state, set_state in the base class ´SamplerNew`. 

This is achieved by adding a class variable `_STATE_KEYS` that contain a set of keys representing the state variables the sampler will work with when calling the **already** implemented `get_state` and `set_state` methods. This reduces the amount of repeated code in each subclass.

Subclassing samplers must now _optionally_ update `_STATE_KEYS` if they expand on the set of variables the represent the state. For example the `ProposalBasedSampler` sampler can expand this by including the `scale` key, as this sampler maintains a `scale` attribute that is updated when running warmup sampling.

A testing framework is added get_state, set_state and checkpointing.

Additionally the `_HISTORY_KEYS` class variable is also added following the same design, but containing variable that representing the sampling history like the samples and acceptance criteria. This specific change introduces public methods get_history and set_history working similarly to how get_state and set_state already works before this PR.

Closes #402

The following related issue #379 is about refactoring the general behavior of get_state and set_state. This current implemented changes introduce 2 class variables that can relatively easily be replaced with another design once we agree on something else for #379.