### PR TITLE
Sampler rework ugla

### DIFF
--- a/cuqi/experimental/mcmc/__init__.py
+++ b/cuqi/experimental/mcmc/__init__.py
@@ -6,3 +6,4 @@ from ._mh import MHNew
 from ._pcn import pCNNew
 from ._rto import LinearRTONew, RegularizedLinearRTONew
 from ._cwmh import CWMHNew
+from ._laplace_approximation import UGLANew

--- a/cuqi/experimental/mcmc/_laplace_approximation.py
+++ b/cuqi/experimental/mcmc/_laplace_approximation.py
@@ -1,0 +1,141 @@
+import scipy as sp
+from scipy.linalg.interpolative import estimate_spectral_norm
+from scipy.sparse.linalg import LinearOperator as scipyLinearOperator
+import numpy as np
+import cuqi
+from cuqi.solver import CGLS, FISTA
+from cuqi.experimental.mcmc import SamplerNew
+from cuqi.array import CUQIarray
+
+class UGLANew(SamplerNew):
+    def __init__(self, target, initial_point=None, maxit=50, tol=1e-4, beta=1e-5, rng=None, **kwargs):
+
+        # Other parameters
+        self.maxit = maxit
+        self.tol = tol
+        self.beta = beta
+        self.rng = rng
+
+        super().__init__(target=target, initial_point=initial_point, **kwargs)
+
+        if initial_point is None: #TODO: Replace later with a getter
+            self.initial_point = np.zeros(self.dim)
+            self._samples = [self.initial_point]
+
+        self.current_point = self.initial_point
+        self._acc = [1] # TODO. Check if we need this
+
+    @property
+    def prior(self):
+        return self.target.prior
+
+    @property
+    def likelihood(self):
+        return self.target.likelihood
+    
+    @property
+    def likelihoods(self):
+        if isinstance(self.target, cuqi.distribution.Posterior):
+            return [self.target.likelihood]
+        elif isinstance(self.target, cuqi.distribution.MultipleLikelihoodPosterior):
+            return self.target.likelihoods
+
+    @property
+    def model(self):
+        return self.target.model     
+    
+    @property
+    def data(self):
+        return self.target.data
+
+    @SamplerNew.target.setter
+    def target(self, value):
+        """ Set the target density. Runs validation of the target. """
+        # Accept tuple of inputs and construct posterior
+        super(UGLANew, type(self)).target.fset(self, value)
+        self._precompute()
+
+    def _precompute(self):
+
+        # Extract diff_op from target prior
+        D = self.target.prior._diff_op
+        n = D.shape[0]
+
+        # Gaussian approximation of LMRF prior as function of x_k
+        def Lk_fun(x_k):
+            dd =  1/np.sqrt((D @ x_k)**2 + self.beta*np.ones(n))
+            W = sp.sparse.diags(dd)
+            return W.sqrt() @ D
+        self.Lk_fun = Lk_fun
+
+        # Now prepare "LinearRTO" type sampler. TODO: Use LinearRTO for this instead
+        self._shift = 0
+
+        # Pre-computations
+        self._model = self.target.likelihood.model   
+        self._data = self.target.likelihood.data
+        self._m = len(self._data)
+        self._L1 = self.target.likelihood.distribution.sqrtprec
+
+        # If prior location is scalar, repeat it to match dimensions
+        if len(self.target.prior.location) == 1:
+            self._priorloc = np.repeat(self.target.prior.location, self.dim)
+        else:
+            self._priorloc = self.target.prior.location
+
+        # Initial Laplace approx
+        # self._L2 = Lk_fun(self.x0)
+        self._L2 = Lk_fun(np.zeros(self.dim))
+        self._L2mu = self._L2@self._priorloc
+        self._b_tild = np.hstack([self._L1@self._data, self._L2mu]) 
+        
+        #self.n = len(self.x0)
+        
+        # Least squares form
+        def M(x, flag):
+            if flag == 1:
+                out1 = self._L1 @ self._model.forward(x)
+                out2 = np.sqrt(1/self.target.prior.scale)*(self._L2 @ x)
+                out  = np.hstack([out1, out2])
+            elif flag == 2:
+                idx = int(self._m)
+                out1 = self._model.adjoint(self._L1.T@x[:idx])
+                out2 = np.sqrt(1/self.target.prior.scale)*(self._L2.T @ x[idx:])
+                out  = out1 + out2                
+            return out
+        self.M = M
+
+    def step(self):
+        # Update Laplace approximation
+        self._L2 = self.Lk_fun(self.current_point)
+        self._L2mu = self._L2@self._priorloc
+        self._b_tild = np.hstack([self._L1@self._data, self._L2mu]) 
+    
+        # Sample from approximate posterior
+        e = cuqi.distribution.Normal(mean=np.zeros(len(self._b_tild)), std=1).sample(rng=self.rng)
+        y = self._b_tild + e # Perturb data
+        print(y)
+        sim = CGLS(self.M, y, self.current_point, self.maxit, self.tol)                     
+        self.current_point, _ = sim.solve()
+        acc = 1
+        return acc
+
+    def tune(self, skip_len, update_count):
+        pass
+    
+    def validate_target(self):
+        # Check target type
+        if not isinstance(self.target, cuqi.distribution.Posterior):
+            raise ValueError(f"To initialize an object of type {self.__class__}, 'target' need to be of type 'cuqi.distribution.Posterior'.")       
+
+        # Check Linear model
+        if not isinstance(self.target.likelihood.model, cuqi.model.LinearModel):
+            raise TypeError("Model needs to be linear")
+
+        # Check Gaussian likelihood
+        if not hasattr(self.target.likelihood.distribution, "sqrtprec"):
+            raise TypeError("Distribution in Likelihood must contain a sqrtprec attribute")
+
+        # Check that prior is LMRF
+        if not isinstance(self.target.prior, cuqi.distribution.LMRF):
+            raise ValueError('Unadjusted Gaussian Laplace approximation (UGLA) requires LMRF prior')

--- a/cuqi/experimental/mcmc/_laplace_approximation.py
+++ b/cuqi/experimental/mcmc/_laplace_approximation.py
@@ -14,28 +14,35 @@ class UGLANew(SamplerNew):
 
     The inner solver is Conjugate Gradient Least Squares (CGLS) solver.
 
-    For more details see: Uribe, Felipe, et al. "A hybrid Gibbs sampler for edge-preserving 
-    tomographic reconstruction with uncertain view angles." arXiv preprint arXiv:2104.06919 (2021).
+    For more details see: Uribe, Felipe, et al. A hybrid Gibbs sampler for edge-preserving 
+    tomographic reconstruction with uncertain view angles. SIAM/ASA Journal on UQ,
+    https://doi.org/10.1137/21M1412268 (2022).
 
     Parameters
     ----------
     target : `cuqi.distribution.Posterior`
         The target posterior distribution to sample.
 
-    initial_point : ndarray
-        Initial parameters. *Optional*
+    initial_point : ndarray, *Optional*
+        Initial parameters.
+        If not provided, it defaults to zeros.
 
     maxit : int
         Maximum number of inner iterations for solver when generating one sample.
+        If not provided, it defaults to 50.
 
     tol : float
-        Tolerance for inner solver. Will stop before maxit if the inner solvers convergence check reaches tol.
+        Tolerance for inner solver.
+        The inner solvers will stop before maxit if convergence check reaches tol.
+        If not provided, it defaults to 1e-4.
 
     beta : float
-        Smoothing parameter for the Gaussian approximation of the Laplace distribution. Larger beta is easier to sample but is a worse approximation.
+        Smoothing parameter for the Gaussian approximation of the Laplace distribution.
+        A larger beta value makes sampling easier but results in a worse approximation.
+        If not provided, it defaults to 1e-5.
 
     callback : callable, *Optional*
-        If set this function will be called after every sample.
+        If set, this function will be called after every sample.
         The signature of the callback function is `callback(sample, sample_index)`,
         where `sample` is the current sample and `sample_index` is the index of the sample.
         An example is shown in demos/demo31_callback.py.

--- a/cuqi/experimental/mcmc/_laplace_approximation.py
+++ b/cuqi/experimental/mcmc/_laplace_approximation.py
@@ -112,9 +112,8 @@ class UGLANew(SamplerNew):
         self._b_tild = np.hstack([self._L1@self._data, self._L2mu]) 
     
         # Sample from approximate posterior
-        e = cuqi.distribution.Normal(mean=np.zeros(len(self._b_tild)), std=1).sample(rng=self.rng)
+        e = np.random.randn(len(self._b_tild))
         y = self._b_tild + e # Perturb data
-        print(y)
         sim = CGLS(self.M, y, self.current_point, self.maxit, self.tol)                     
         self.current_point, _ = sim.solve()
         acc = 1

--- a/cuqi/experimental/mcmc/_laplace_approximation.py
+++ b/cuqi/experimental/mcmc/_laplace_approximation.py
@@ -42,11 +42,6 @@ class UGLANew(SamplerNew):
     """
     def __init__(self, target, initial_point=None, maxit=50, tol=1e-4, beta=1e-5, **kwargs):
 
-        # Parameters (beta is used in target setter)
-        self.maxit = maxit
-        self.tol = tol
-        self.beta = beta
-
         super().__init__(target=target, initial_point=initial_point, **kwargs)
 
         if initial_point is None: #TODO: Replace later with a getter
@@ -55,6 +50,11 @@ class UGLANew(SamplerNew):
 
         self.current_point = self.initial_point
         self._acc = [1] # TODO. Check if we need this
+
+        # Parameters
+        self.maxit = maxit
+        self.tol = tol
+        self.beta = beta
 
     @property
     def prior(self):

--- a/cuqi/experimental/mcmc/_laplace_approximation.py
+++ b/cuqi/experimental/mcmc/_laplace_approximation.py
@@ -38,7 +38,7 @@ class UGLANew(SamplerNew):
 
     beta : float
         Smoothing parameter for the Gaussian approximation of the Laplace distribution.
-        A small value in the range of 1e-7 to 1e-3 is recommended, though vallues out of this 
+        A small value in the range of 1e-7 to 1e-3 is recommended, though values out of this 
         range might give better results in some cases. Generally, a larger beta value makes 
         sampling easier but results in a worse approximation. See details in Section 3.3 of the paper.
         If not provided, it defaults to 1e-5.

--- a/cuqi/experimental/mcmc/_laplace_approximation.py
+++ b/cuqi/experimental/mcmc/_laplace_approximation.py
@@ -72,15 +72,8 @@ class UGLANew(SamplerNew):
     def data(self):
         return self.target.data
 
-    @SamplerNew.target.setter
-    def target(self, value):
-        """ Set the target density. Runs validation of the target. """
-        # Accept tuple of inputs and construct posterior
-        super(UGLANew, type(self)).target.fset(self, value)
-        self._precompute()
-
-    def _precompute(self):
-        # Extract diff_op from target prior
+    def _pre_warmup(self):
+        super()._pre_warmup()
         D = self.prior._diff_op
         n = D.shape[0]
 
@@ -101,8 +94,7 @@ class UGLANew(SamplerNew):
             self._priorloc = self.prior.location
 
         # Initial Laplace approx
-        # self._L2 = Lk_fun(self.x0)
-        self._L2 = Lk_fun(np.zeros(self.dim)) #TODO: fix this
+        self._L2 = Lk_fun(self.initial_point)
         self._L2mu = self._L2@self._priorloc
         self._b_tild = np.hstack([self._L1@self.data, self._L2mu]) 
         
@@ -119,6 +111,9 @@ class UGLANew(SamplerNew):
                 out  = out1 + out2                
             return out
         self.M = M
+
+    def _pre_sample(self):
+        self._pre_warmup()
 
     def step(self):
         # Update Laplace approximation

--- a/cuqi/experimental/mcmc/_laplace_approximation.py
+++ b/cuqi/experimental/mcmc/_laplace_approximation.py
@@ -38,7 +38,9 @@ class UGLANew(SamplerNew):
 
     beta : float
         Smoothing parameter for the Gaussian approximation of the Laplace distribution.
-        A larger beta value makes sampling easier but results in a worse approximation.
+        A small value in the range of 1e-7 to 1e-3 is recommended, though vallues out of this 
+        range might give better results in some cases. Generally, a larger beta value makes 
+        sampling easier but results in a worse approximation. See details in Section 3.3 of the paper.
         If not provided, it defaults to 1e-5.
 
     callback : callable, *Optional*

--- a/tests/zexperimental/test_mcmc.py
+++ b/tests/zexperimental/test_mcmc.py
@@ -333,8 +333,8 @@ def test_NUTS_regression_warmup(target: cuqi.density.Density):
 checkpoint_targets = [
     cuqi.experimental.mcmc.ULANew(cuqi.testproblem.Deconvolution1D().posterior, scale=0.0001),
     cuqi.experimental.mcmc.MALANew(cuqi.testproblem.Deconvolution1D().posterior, scale=0.0001),
-    cuqi.experimental.mcmc.LinearRTONew(cuqi.testproblem.Deconvolution1D().posterior)#,
-    #cuqi.experimental.mcmc.UGLANew(create_lmrf_prior_target(dim=16))
+    cuqi.experimental.mcmc.LinearRTONew(cuqi.testproblem.Deconvolution1D().posterior),
+    cuqi.experimental.mcmc.UGLANew(create_lmrf_prior_target(dim=16))
 ]
     
 # List of samplers from cuqi.experimental.mcmc that should be skipped for checkpoint testing
@@ -346,7 +346,6 @@ skip_checkpoint = [
     cuqi.experimental.mcmc.CWMHNew,
     cuqi.experimental.mcmc.RegularizedLinearRTONew, # Due to the _choose_stepsize method
     cuqi.experimental.mcmc.NUTSNew,
-    cuqi.experimental.mcmc.UGLANew
 ]
 
 def test_ensure_all_not_skipped_samplers_are_tested_for_checkpointing():
@@ -410,9 +409,9 @@ state_history_targets = [
     cuqi.experimental.mcmc.CWMHNew(cuqi.testproblem.Deconvolution1D(dim=10).posterior, scale=0.5),
     cuqi.experimental.mcmc.ULANew(cuqi.testproblem.Deconvolution1D(dim=10).posterior, scale=0.0001),
     cuqi.experimental.mcmc.MALANew(cuqi.testproblem.Deconvolution1D(dim=10).posterior, scale=0.0001),
-    cuqi.experimental.mcmc.LinearRTONew(cuqi.testproblem.Deconvolution1D(dim=10).posterior)#,
-    #cuqi.experimental.mcmc.RegularizedLinearRTONew(create_regularized_target(dim=10)),
-    #cuqi.experimental.mcmc.UGLANew(create_lmrf_prior_target(dim=32)),
+    cuqi.experimental.mcmc.LinearRTONew(cuqi.testproblem.Deconvolution1D(dim=10).posterior),
+    cuqi.experimental.mcmc.RegularizedLinearRTONew(create_regularized_target(dim=10)),
+    cuqi.experimental.mcmc.UGLANew(create_lmrf_prior_target(dim=32)),
 ]
 
 

--- a/tests/zexperimental/test_mcmc.py
+++ b/tests/zexperimental/test_mcmc.py
@@ -345,8 +345,7 @@ skip_checkpoint = [
     cuqi.experimental.mcmc.pCNNew,
     cuqi.experimental.mcmc.CWMHNew,
     cuqi.experimental.mcmc.RegularizedLinearRTONew, # Due to the _choose_stepsize method
-    cuqi.experimental.mcmc.NUTSNew,
-    # cuqi.experimental.mcmc.UGLANew
+    cuqi.experimental.mcmc.NUTSNew
 ]
 
 def test_ensure_all_not_skipped_samplers_are_tested_for_checkpointing():
@@ -411,7 +410,7 @@ state_history_targets = [
     cuqi.experimental.mcmc.ULANew(cuqi.testproblem.Deconvolution1D(dim=10).posterior, scale=0.0001),
     cuqi.experimental.mcmc.MALANew(cuqi.testproblem.Deconvolution1D(dim=10).posterior, scale=0.0001),
     cuqi.experimental.mcmc.LinearRTONew(cuqi.testproblem.Deconvolution1D(dim=10).posterior),
-    #cuqi.experimental.mcmc.RegularizedLinearRTONew(create_regularized_target(dim=10)),
+    cuqi.experimental.mcmc.RegularizedLinearRTONew(create_regularized_target(dim=16)),
     cuqi.experimental.mcmc.UGLANew(create_lmrf_prior_target(dim=32)),
 ]
 

--- a/tests/zexperimental/test_mcmc.py
+++ b/tests/zexperimental/test_mcmc.py
@@ -346,6 +346,7 @@ skip_checkpoint = [
     cuqi.experimental.mcmc.CWMHNew,
     cuqi.experimental.mcmc.RegularizedLinearRTONew, # Due to the _choose_stepsize method
     cuqi.experimental.mcmc.NUTSNew,
+    # cuqi.experimental.mcmc.UGLANew
 ]
 
 def test_ensure_all_not_skipped_samplers_are_tested_for_checkpointing():
@@ -410,7 +411,7 @@ state_history_targets = [
     cuqi.experimental.mcmc.ULANew(cuqi.testproblem.Deconvolution1D(dim=10).posterior, scale=0.0001),
     cuqi.experimental.mcmc.MALANew(cuqi.testproblem.Deconvolution1D(dim=10).posterior, scale=0.0001),
     cuqi.experimental.mcmc.LinearRTONew(cuqi.testproblem.Deconvolution1D(dim=10).posterior),
-    cuqi.experimental.mcmc.RegularizedLinearRTONew(create_regularized_target(dim=10)),
+    #cuqi.experimental.mcmc.RegularizedLinearRTONew(create_regularized_target(dim=10)),
     cuqi.experimental.mcmc.UGLANew(create_lmrf_prior_target(dim=32)),
 ]
 

--- a/tests/zexperimental/test_mcmc.py
+++ b/tests/zexperimental/test_mcmc.py
@@ -336,7 +336,7 @@ checkpoint_targets = [
     cuqi.experimental.mcmc.ULANew(cuqi.testproblem.Deconvolution1D().posterior, scale=0.0001),
     cuqi.experimental.mcmc.MALANew(cuqi.testproblem.Deconvolution1D().posterior, scale=0.0001),
     cuqi.experimental.mcmc.LinearRTONew(cuqi.testproblem.Deconvolution1D().posterior),
-    # cuqi.experimental.mcmc.UGLANew(create_lmrf_prior_target(dim=16)) #TODO: this cause a error in MHNew
+    cuqi.experimental.mcmc.UGLANew(create_lmrf_prior_target(dim=16))
 ]
     
 # List of samplers from cuqi.experimental.mcmc that should be skipped for checkpoint testing
@@ -347,7 +347,6 @@ skip_checkpoint = [
     cuqi.experimental.mcmc.pCNNew,
     cuqi.experimental.mcmc.CWMHNew,
     cuqi.experimental.mcmc.RegularizedLinearRTONew, # Due to the _choose_stepsize method
-    cuqi.experimental.mcmc.UGLANew,
     cuqi.experimental.mcmc.NUTSNew
 ]
 

--- a/tests/zexperimental/test_mcmc.py
+++ b/tests/zexperimental/test_mcmc.py
@@ -406,13 +406,14 @@ def test_checkpointing(sampler: cuqi.experimental.mcmc.SamplerNew):
 
 
 state_history_targets = [
-    cuqi.experimental.mcmc.MHNew(cuqi.testproblem.Deconvolution1D(dim=10).posterior, scale=0.5),
+    cuqi.experimental.mcmc.MHNew(cuqi.testproblem.Deconvolution1D(dim=10).posterior, scale=0.0001),
     cuqi.experimental.mcmc.pCNNew(cuqi.testproblem.Deconvolution1D(dim=10).posterior, scale=0.001),
     cuqi.experimental.mcmc.CWMHNew(cuqi.testproblem.Deconvolution1D(dim=10).posterior, scale=0.5),
     cuqi.experimental.mcmc.ULANew(cuqi.testproblem.Deconvolution1D(dim=10).posterior, scale=0.0001),
     cuqi.experimental.mcmc.MALANew(cuqi.testproblem.Deconvolution1D(dim=10).posterior, scale=0.0001),
     cuqi.experimental.mcmc.LinearRTONew(cuqi.testproblem.Deconvolution1D(dim=10).posterior),
-    cuqi.experimental.mcmc.RegularizedLinearRTONew(create_regularized_target(dim=10), stepsize=0.0001),
+    cuqi.experimental.mcmc.RegularizedLinearRTONew(create_regularized_target(dim=10)),
+    cuqi.experimental.mcmc.UGLANew(create_lmrf_prior_target(dim=32)),
 ]
 
 


### PR DESCRIPTION
fixed #381 

- We followed a similar strategy as in [NUTS](https://github.com/CUQI-DTU/CUQIpy/blob/main/cuqi/experimental/mcmc/_hmc.py), and the pre-computation work is now done in `_pre_warmup` and `_pre_sample` functions.
- A local target is created within `test_UGLA_regression_sample`, instead of a global target list, to avoid breaking randomness in other unit tests.
- Further work is needed in the future to base UGLA on LinearRTO #410 .
