### PR TITLE
reduce time on zexperimental tests

### DIFF
--- a/tests/zexperimental/test_mcmc.py
+++ b/tests/zexperimental/test_mcmc.py
@@ -6,7 +6,7 @@ import inspect
 def assert_true_if_sampling_is_equivalent(
         sampler_old: cuqi.sampler.Sampler,
         sampler_new: cuqi.experimental.mcmc.SamplerNew,
-        Ns=100, atol=1e-1, old_idx=[0, None], new_idx=[0, -1]):
+        Ns=20, atol=1e-1, old_idx=[0, None], new_idx=[0, -1]):
     """ Assert that the samples from the old and new sampler are equivalent.
 
     Ns: int
@@ -37,7 +37,8 @@ def assert_true_if_sampling_is_equivalent(
 
 def assert_true_if_warmup_is_equivalent(
         sampler_old: cuqi.sampler.Sampler,
-        sampler_new: cuqi.experimental.mcmc.SamplerNew, Ns=100, Nb=100,
+        sampler_new: cuqi.experimental.mcmc.SamplerNew,
+        Ns=20, Nb=20,
         strategy="MH_like", old_idx=[0, None], new_idx=[0, None]):
     """ Assert that the samples from the old and new sampler are equivalent.
      
@@ -94,7 +95,6 @@ def assert_true_if_warmup_is_equivalent(
 
 targets = [
     cuqi.testproblem.Deconvolution1D(dim=2).posterior,
-    cuqi.testproblem.Deconvolution1D(dim=20).posterior,
     cuqi.testproblem.Deconvolution1D(dim=128).posterior
 ]
 """ List of targets to test against. """
@@ -222,12 +222,10 @@ def create_multiple_likelihood_posterior_regularized_target(dim=16):
     return target
 
 regularized_targets = [
-    create_regularized_target(dim=32),
-    create_regularized_target(dim=64),
+    create_regularized_target(dim=16),
     create_regularized_target(dim=128)
 ] + [
-    create_multiple_likelihood_posterior_regularized_target(dim=32),
-    create_multiple_likelihood_posterior_regularized_target(dim=64),
+    create_multiple_likelihood_posterior_regularized_target(dim=16),
     create_multiple_likelihood_posterior_regularized_target(dim=128)
 ]
 
@@ -255,7 +253,7 @@ def create_lmrf_prior_target(dim=16):
 
 
 
-@pytest.mark.parametrize("target_dim", [32, 64, 128])
+@pytest.mark.parametrize("target_dim", [16, 128])
 def test_UGLA_regression_sample(target_dim):
     """Test the UGLA sampler regression."""
     target = create_lmrf_prior_target(dim=target_dim)
@@ -263,7 +261,7 @@ def test_UGLA_regression_sample(target_dim):
     sampler_new = cuqi.experimental.mcmc.UGLANew(target)
     assert_true_if_sampling_is_equivalent(sampler_old, sampler_new)
 
-@pytest.mark.parametrize("target_dim", [32, 64, 128])
+@pytest.mark.parametrize("target_dim", [16, 128])
 def test_UGLA_regression_warmup(target_dim):
     """Test the UGLA sampler regression."""
     target = create_lmrf_prior_target(dim=target_dim)


### PR DESCRIPTION
fixed #413 

Issue: the tests on the new samplers take too much time and make the local pytest and github build very slow. Tests on `RegularizedLinearRTO` and `NUTS` are the most expensive ones.
Solution: as suggested by Nicolai, we 
 - reduce the default length of the chain from 100 to 20
 - keep only 2 of the default targets (one being dim 2 and the other dim 128)
 - keep only 4 of the regularized targets for `RegularizedLinearRTO` ([single likelihood, multiple likelihood] x [dim 16, dim 128])

The below shows the top 15 time-consuming tests in `tests/zexperimental/test_mcmc.py` before and after the change:
```bash
(before) slowest durations ==============================================================================
4.82s call     tests/zexperimental/test_mcmc.py::test_RegularizedLinearRTO_regression_warmup[target5]
2.94s call     tests/zexperimental/test_mcmc.py::test_RegularizedLinearRTO_regression_warmup[target2]
2.67s call     tests/zexperimental/test_mcmc.py::test_NUTS_regression_warmup[target1]
2.52s call     tests/zexperimental/test_mcmc.py::test_RegularizedLinearRTO_regression_sample[target5]
2.48s call     tests/zexperimental/test_mcmc.py::test_NUTS_regression_sample[target1]
2.38s call     tests/zexperimental/test_mcmc.py::test_RegularizedLinearRTO_regression_warmup[target4]
2.08s call     tests/zexperimental/test_mcmc.py::test_RegularizedLinearRTO_regression_warmup[target3]
1.86s call     tests/zexperimental/test_mcmc.py::test_NUTS_regression_warmup[target2]
1.80s call     tests/zexperimental/test_mcmc.py::test_UGLA_regression_warmup[128]
1.67s call     tests/zexperimental/test_mcmc.py::test_RegularizedLinearRTO_regression_sample[target2]
1.59s call     tests/zexperimental/test_mcmc.py::test_UGLA_regression_warmup[64]
1.54s call     tests/zexperimental/test_mcmc.py::test_RegularizedLinearRTO_regression_warmup[target1]
1.47s call     tests/zexperimental/test_mcmc.py::test_CWMH_regression_warmup[target2]
1.29s call     tests/zexperimental/test_mcmc.py::test_RegularizedLinearRTO_regression_warmup[target0]
1.29s call     tests/zexperimental/test_mcmc.py::test_RegularizedLinearRTO_regression_sample[target4]

```

```bash
(after) slowest durations ==============================================================================
1.31s call     tests/zexperimental/test_mcmc.py::test_NUTS_regression_warmup[target1]
0.95s call     tests/zexperimental/test_mcmc.py::test_RegularizedLinearRTO_regression_warmup[target3]
0.78s call     tests/zexperimental/test_mcmc.py::test_NUTS_regression_sample_tune_first_step_only[target1]
0.56s call     tests/zexperimental/test_mcmc.py::test_RegularizedLinearRTO_regression_warmup[target1]
0.55s call     tests/zexperimental/test_mcmc.py::test_RegularizedLinearRTO_regression_sample[target3]
0.42s call     tests/zexperimental/test_mcmc.py::test_CWMH_regression_warmup[target1]
0.36s call     tests/zexperimental/test_mcmc.py::test_RegularizedLinearRTO_regression_warmup[target2]
0.33s call     tests/zexperimental/test_mcmc.py::test_MH_regression_sample[target0]
0.32s call     tests/zexperimental/test_mcmc.py::test_UGLA_regression_warmup[128]
0.31s call     tests/zexperimental/test_mcmc.py::test_checkpointing[sampler3]
0.28s call     tests/zexperimental/test_mcmc.py::test_RegularizedLinearRTO_regression_sample[target1]
0.27s call     tests/zexperimental/test_mcmc.py::test_checkpointing[sampler2]
0.27s call     tests/zexperimental/test_mcmc.py::test_state_is_fully_updated_after_warmup_step[sampler6]
0.24s call     tests/zexperimental/test_mcmc.py::test_RegularizedLinearRTO_regression_warmup[target0]
0.24s call     tests/zexperimental/test_mcmc.py::test_NUTS_regression_sample_tune_first_step_only[target0]
```