### PR TITLE
Add tune to pCN and rename pCN to PCN

### DIFF
--- a/cuqi/experimental/mcmc/__init__.py
+++ b/cuqi/experimental/mcmc/__init__.py
@@ -3,7 +3,7 @@
 from ._sampler import SamplerNew, ProposalBasedSamplerNew
 from ._langevin_algorithm import ULANew, MALANew
 from ._mh import MHNew
-from ._pcn import pCNNew
+from ._pcn import PCNNew
 from ._rto import LinearRTONew, RegularizedLinearRTONew
 from ._cwmh import CWMHNew
 from ._laplace_approximation import UGLANew

--- a/cuqi/experimental/mcmc/_pcn.py
+++ b/cuqi/experimental/mcmc/_pcn.py
@@ -20,7 +20,7 @@ class PCNNew(SamplerNew):  # Refactor to Proposal-based sampler?
         # parameters used in the Robbins-Monro recursion for tuning the scale parameter
         # see details and reference in the tune method
         self.lambd = self.scale
-        self.star_acc = 0.44
+        self.star_acc = 0.44 # target acceptance rate
 
     def validate_target(self):
         try:

--- a/cuqi/experimental/mcmc/_pcn.py
+++ b/cuqi/experimental/mcmc/_pcn.py
@@ -89,14 +89,13 @@ class PCNNew(SamplerNew):  # Refactor to Proposal-based sampler?
 
     def _pre_warmup(self):
         self.lambd = self.scale
+        self.star_acc = 0.44
 
     def tune(self, skip_len, update_count):
-        
-        star_acc = 0.44
-        print("self._acc[-skip_len:]", self._acc[-skip_len:])
+
         hat_acc = np.mean(self._acc[-skip_len:])
 
         zeta = 1/np.sqrt(update_count+1)
-        self.lambd = np.exp(np.log(self.lambd) + zeta*(hat_acc-star_acc))
+        self.lambd = np.exp(np.log(self.lambd) + zeta*(hat_acc-self.star_acc))
 
         self.scale = min(self.lambd, 1)

--- a/cuqi/experimental/mcmc/_pcn.py
+++ b/cuqi/experimental/mcmc/_pcn.py
@@ -17,6 +17,10 @@ class PCNNew(SamplerNew):  # Refactor to Proposal-based sampler?
 
         self._acc = [1] # TODO. Check if we need this
 
+        # parameters for tune method
+        self.lambd = self.scale
+        self.star_acc = 0.44
+
     def validate_target(self):
         try:
             if isinstance(self.prior, (cuqi.distribution.Gaussian, cuqi.distribution.Normal)):
@@ -74,10 +78,6 @@ class PCNNew(SamplerNew):  # Refactor to Proposal-based sampler?
             self._loglikelihood = lambda x : self.likelihood.logd(x)
         else:
             raise ValueError(f"To initialize an object of type {self.__class__}, 'target' need to be of type 'cuqi.distribution.Posterior'.")
-        
-        #TODO:
-        #if not isinstance(self.prior,(cuqi.distribution.Gaussian, cuqi.distribution.Normal)):
-        #    raise ValueError("The prior distribution of the target need to be Gaussian")
 
     @property
     def dim(self): # TODO. Check if we need this. Implemented in base class
@@ -86,10 +86,6 @@ class PCNNew(SamplerNew):  # Refactor to Proposal-based sampler?
         elif hasattr(self,'target') and isinstance(self.target,tuple) and len(self.target)==2:
             self._dim = self.target[0].dim
         return self._dim
-
-    def _pre_warmup(self):
-        self.lambd = self.scale
-        self.star_acc = 0.44
 
     def tune(self, skip_len, update_count):
 

--- a/cuqi/experimental/mcmc/_pcn.py
+++ b/cuqi/experimental/mcmc/_pcn.py
@@ -18,6 +18,7 @@ class PCNNew(SamplerNew):  # Refactor to Proposal-based sampler?
         self._acc = [1] # TODO. Check if we need this
 
         # parameters used in the Robbins-Monro recursion for tuning the scale parameter
+        # see details and reference in the tune method
         self.lambd = self.scale
         self.star_acc = 0.44
 

--- a/cuqi/experimental/mcmc/_pcn.py
+++ b/cuqi/experimental/mcmc/_pcn.py
@@ -87,5 +87,16 @@ class pCNNew(SamplerNew):  # Refactor to Proposal-based sampler?
             self._dim = self.target[0].dim
         return self._dim
 
+    def _pre_warmup(self):
+        self.lambd = self.scale
+
     def tune(self, skip_len, update_count):
-        pass
+        
+        star_acc = 0.44
+        print("self._acc[-skip_len:]", self._acc[-skip_len:])
+        hat_acc = np.mean(self._acc[-skip_len:])
+
+        zeta = 1/np.sqrt(update_count+1)
+        self.lambd = np.exp(np.log(self.lambd) + zeta*(hat_acc-star_acc))
+
+        self.scale = min(self.lambd, 1)

--- a/cuqi/experimental/mcmc/_pcn.py
+++ b/cuqi/experimental/mcmc/_pcn.py
@@ -3,7 +3,7 @@ import cuqi
 from cuqi.experimental.mcmc import SamplerNew
 from cuqi.array import CUQIarray
 
-class pCNNew(SamplerNew):  # Refactor to Proposal-based sampler?
+class PCNNew(SamplerNew):  # Refactor to Proposal-based sampler?
 
     _STATE_KEYS = SamplerNew._STATE_KEYS.union({'scale', 'current_likelihood_logd'})
 
@@ -29,7 +29,7 @@ class pCNNew(SamplerNew):  # Refactor to Proposal-based sampler?
     def step(self):
         # propose state
         xi = self.prior.sample(1).flatten()   # sample from the prior
-        x_star = np.sqrt(1-self.scale**2)*self.current_point + self.scale*xi   # pCN proposal
+        x_star = np.sqrt(1-self.scale**2)*self.current_point + self.scale*xi   # PCN proposal
 
         # evaluate target
         loglike_eval_star =  self._loglikelihood(x_star) 

--- a/cuqi/experimental/mcmc/_pcn.py
+++ b/cuqi/experimental/mcmc/_pcn.py
@@ -20,7 +20,7 @@ class PCNNew(SamplerNew):  # Refactor to Proposal-based sampler?
         # parameters used in the Robbins-Monro recursion for tuning the scale parameter
         # see details and reference in the tune method
         self.lambd = self.scale
-        self.star_acc = 0.44 # target acceptance rate
+        self.star_acc = 0.234 # target acceptance rate
 
     def validate_target(self):
         try:
@@ -93,6 +93,7 @@ class PCNNew(SamplerNew):  # Refactor to Proposal-based sampler?
         Tune the scale parameter of the PCN sampler.
         The tuning is based on algorithm 4 in Andrieu, Christophe, and Johannes Thoms. 
         "A tutorial on adaptive MCMC." Statistics and computing 18 (2008): 343-373.
+        Note: the tuning algorithm here is the same as the one used in MH sampler.
         """
 
         # average acceptance rate in the past skip_len iterations

--- a/cuqi/experimental/mcmc/_pcn.py
+++ b/cuqi/experimental/mcmc/_pcn.py
@@ -5,7 +5,7 @@ from cuqi.array import CUQIarray
 
 class PCNNew(SamplerNew):  # Refactor to Proposal-based sampler?
 
-    _STATE_KEYS = SamplerNew._STATE_KEYS.union({'scale', 'current_likelihood_logd'})
+    _STATE_KEYS = SamplerNew._STATE_KEYS.union({'scale', 'current_likelihood_logd', 'lambd'})
 
     def __init__(self, target, scale=1.0, **kwargs):
 

--- a/cuqi/experimental/mcmc/_pcn.py
+++ b/cuqi/experimental/mcmc/_pcn.py
@@ -20,7 +20,7 @@ class PCNNew(SamplerNew):  # Refactor to Proposal-based sampler?
         # parameters used in the Robbins-Monro recursion for tuning the scale parameter
         # see details and reference in the tune method
         self.lambd = self.scale
-        self.star_acc = 0.234 # target acceptance rate
+        self.star_acc = 0.44 #TODO: 0.234 # target acceptance rate
 
     def validate_target(self):
         try:

--- a/tests/zexperimental/test_mcmc.py
+++ b/tests/zexperimental/test_mcmc.py
@@ -115,20 +115,20 @@ def test_MH_regression_warmup(target: cuqi.density.Density):
     sampler_new = cuqi.experimental.mcmc.MHNew(target, scale=1)
     assert_true_if_warmup_is_equivalent(sampler_old, sampler_new)
 
-# ============ pCN ============
+# ============ PCN ============
 
 @pytest.mark.parametrize("target", targets)
 def test_pCN_regression_sample(target: cuqi.density.Density):
     """Test the pCN sampler regression."""
     sampler_old = cuqi.sampler.pCN(target, scale=1)
-    sampler_new = cuqi.experimental.mcmc.pCNNew(target, scale=1)
+    sampler_new = cuqi.experimental.mcmc.PCNNew(target, scale=1)
     assert_true_if_sampling_is_equivalent(sampler_old, sampler_new)
 
 @pytest.mark.parametrize("target", targets)
 def test_pCN_regression_warmup(target: cuqi.density.Density):
     """Test the pCN sampler regression."""
     sampler_old = cuqi.sampler.pCN(target, scale=1)
-    sampler_new = cuqi.experimental.mcmc.pCNNew(target, scale=1)
+    sampler_new = cuqi.experimental.mcmc.PCNNew(target, scale=1)
     assert_true_if_warmup_is_equivalent(sampler_old, sampler_new)
 
 # ============ ULA ============
@@ -339,7 +339,7 @@ skip_checkpoint = [
     cuqi.experimental.mcmc.SamplerNew,
     cuqi.experimental.mcmc.ProposalBasedSamplerNew,
     cuqi.experimental.mcmc.MHNew,
-    cuqi.experimental.mcmc.pCNNew,
+    cuqi.experimental.mcmc.PCNNew,
     cuqi.experimental.mcmc.CWMHNew,
     cuqi.experimental.mcmc.RegularizedLinearRTONew, # Due to the _choose_stepsize method
     cuqi.experimental.mcmc.NUTSNew
@@ -402,7 +402,7 @@ def test_checkpointing(sampler: cuqi.experimental.mcmc.SamplerNew):
 
 state_history_targets = [
     cuqi.experimental.mcmc.MHNew(cuqi.testproblem.Deconvolution1D(dim=10).posterior, scale=0.0001),
-    cuqi.experimental.mcmc.pCNNew(cuqi.testproblem.Deconvolution1D(dim=10).posterior, scale=0.001),
+    cuqi.experimental.mcmc.PCNNew(cuqi.testproblem.Deconvolution1D(dim=10).posterior, scale=0.001),
     cuqi.experimental.mcmc.CWMHNew(cuqi.testproblem.Deconvolution1D(dim=10).posterior, scale=0.5),
     cuqi.experimental.mcmc.ULANew(cuqi.testproblem.Deconvolution1D(dim=10).posterior, scale=0.0001),
     cuqi.experimental.mcmc.MALANew(cuqi.testproblem.Deconvolution1D(dim=10).posterior, scale=0.0001),
@@ -453,7 +453,7 @@ def test_history_keys(sampler: cuqi.experimental.mcmc.SamplerNew):
 # Dictionary to store keys that are not expected to be updated after warmup.
 # Likely due to not implemented feature in the sampler.
 state_exception_keys = {
-    cuqi.experimental.mcmc.pCNNew: 'scale',
+    cuqi.experimental.mcmc.PCNNew: 'scale',
     cuqi.experimental.mcmc.ULANew: 'scale',
     cuqi.experimental.mcmc.MALANew: 'scale',
 }

--- a/tests/zexperimental/test_mcmc.py
+++ b/tests/zexperimental/test_mcmc.py
@@ -453,7 +453,6 @@ def test_history_keys(sampler: cuqi.experimental.mcmc.SamplerNew):
 # Dictionary to store keys that are not expected to be updated after warmup.
 # Likely due to not implemented feature in the sampler.
 state_exception_keys = {
-    cuqi.experimental.mcmc.PCNNew: 'scale',
     cuqi.experimental.mcmc.ULANew: 'scale',
     cuqi.experimental.mcmc.MALANew: 'scale',
 }

--- a/tests/zexperimental/test_mcmc.py
+++ b/tests/zexperimental/test_mcmc.py
@@ -125,7 +125,6 @@ def test_pCN_regression_sample(target: cuqi.density.Density):
     assert_true_if_sampling_is_equivalent(sampler_old, sampler_new)
 
 @pytest.mark.parametrize("target", targets)
-@pytest.mark.xfail(reason="The warmup is not equivalent at this point for pCN sampler.")
 def test_pCN_regression_warmup(target: cuqi.density.Density):
     """Test the pCN sampler regression."""
     sampler_old = cuqi.sampler.pCN(target, scale=1)

--- a/tests/zexperimental/test_mcmc.py
+++ b/tests/zexperimental/test_mcmc.py
@@ -120,15 +120,15 @@ def test_MH_regression_warmup(target: cuqi.density.Density):
 @pytest.mark.parametrize("target", targets)
 def test_pCN_regression_sample(target: cuqi.density.Density):
     """Test the pCN sampler regression."""
-    sampler_old = cuqi.sampler.pCN(target, scale=1)
-    sampler_new = cuqi.experimental.mcmc.PCNNew(target, scale=1)
+    sampler_old = cuqi.sampler.pCN(target, scale=0.001)
+    sampler_new = cuqi.experimental.mcmc.PCNNew(target, scale=0.001)
     assert_true_if_sampling_is_equivalent(sampler_old, sampler_new)
 
 @pytest.mark.parametrize("target", targets)
 def test_pCN_regression_warmup(target: cuqi.density.Density):
     """Test the pCN sampler regression."""
-    sampler_old = cuqi.sampler.pCN(target, scale=1)
-    sampler_new = cuqi.experimental.mcmc.PCNNew(target, scale=1)
+    sampler_old = cuqi.sampler.pCN(target, scale=0.001)
+    sampler_new = cuqi.experimental.mcmc.PCNNew(target, scale=0.001)
     assert_true_if_warmup_is_equivalent(sampler_old, sampler_new)
 
 # ============ ULA ============


### PR DESCRIPTION
fixed #415 
fixed #403

What's the issue:
- In `pCNNew`, `tune` method was empty and the unit test on `warmup` was omitted;
- `pCNNew` should be `PCNNew` to keep consistency with other samplers, like `ULA` and `LinearRTO`

What I did:
- added `tune` which is basically copy-paste from the old sampler;
- initialized `self.lambd` in constructor;
- activated the unit test on `PCNNew`'s `warmup` in `tests/zexperimental/test_mcmc.py`;
- removed `PCNNew` from exception for unit test on history state in `tests/zexperimental/test_mcmc.py`;
- deleted a comment on checking if prior is `Gaussian` as it is now being checked in `validate_target`;
- renamed `pCNNew` to `PCNNew` while keeping the old `pCN` untouched.