### PR TITLE
Let Gaussian accept LinearOperator represented sqrtprec

### DIFF
--- a/cuqi/distribution/_gaussian.py
+++ b/cuqi/distribution/_gaussian.py
@@ -9,7 +9,7 @@ import scipy.linalg as splinalg
 
 from cuqi import config
 from cuqi.geometry import _get_identity_geometries
-from cuqi.utilities import force_ndarray, sparse_cholesky
+from cuqi.utilities import force_ndarray, sparse_cholesky, check_if_conditional_from_attr
 from cuqi.distribution import Distribution
 
 # We potentially allow the use of sksparse.cholmod for sparse Cholesky
@@ -191,7 +191,7 @@ class Gaussian(Distribution):
         value = force_ndarray(value)
         self._sqrtcov = value
         self._cov = None # Reset covariance (in case it was computed before)      
-        if (value is not None) and (not callable(value)): #TODO: problem here
+        if (value is not None) and (not callable(value)):
             if self.dim > config.MIN_DIM_SPARSE:
                 sparse_flag = True # do sparse computations
             else:
@@ -214,7 +214,7 @@ class Gaussian(Distribution):
         value = force_ndarray(value)
         self._sqrtprec = value
         self._cov = None # Reset covariance (in case it was computed before)
-        if (value is not None) and (not callable(value)):  
+        if not check_if_conditional_from_attr(value):
             if self.dim > config.MIN_DIM_SPARSE:
                 sparse_flag = True # do sparse computations
             else:
@@ -631,7 +631,7 @@ def get_sqrtprec_from_sqrtprec(dim, sqrtprec, sparse_flag):
     dim : int
         Dimension of the sqrtprec matrix.
     
-    sqrtprec : 1-d or 2-d ndarray or sparse matrix
+    sqrtprec : 1-d or 2-d ndarray or sparse matrix or scipy.sparse.linalg.LinearOperator
         Square root of precision matrix. If 1-dimensional, then assumed to be a diagonal matrix.
 
     sparse_flag: bool
@@ -666,18 +666,20 @@ def get_sqrtprec_from_sqrtprec(dim, sqrtprec, sparse_flag):
         logdet = np.sum(-np.log(sqrtprec.data**2))
         rank = dim
 
+    # sqrtprec is LinearOperator
+    elif isinstance(sqrtprec, spa.linalg.LinearOperator):
+        sqrtprec = sqrtprec
+        if hasattr(sqrtprec, 'logdet'):
+            logdet = sqrtprec.logdet
+        else:
+            logdet = None
+        rank = dim
+
     # sqrtprec diagonal
     elif np.count_nonzero(sqrtprec-np.diag(sqrtprec.diagonal())) == 0:
         stdinv = sqrtprec.diagonal()
         precision = stdinv**2
         logdet = np.sum(-np.log(precision))
-        rank = dim
-
-    # sqrtprec is LinearOperator (only for RTOs)
-    elif isinstance(sqrtprec, spa.linalg.LinearOperator):
-        sqrtprec = sqrtprec
-        if hasattr(sqrtprec, 'logdet'):
-            logdet = sqrtprec.logdet
         rank = dim
 
     # sqrtprec is full

--- a/cuqi/distribution/_gaussian.py
+++ b/cuqi/distribution/_gaussian.py
@@ -668,7 +668,6 @@ def get_sqrtprec_from_sqrtprec(dim, sqrtprec, sparse_flag):
 
     # sqrtprec is LinearOperator
     elif isinstance(sqrtprec, spa.linalg.LinearOperator):
-        sqrtprec = sqrtprec
         if hasattr(sqrtprec, 'logdet'):
             logdet = sqrtprec.logdet
         else:

--- a/cuqi/distribution/_gaussian.py
+++ b/cuqi/distribution/_gaussian.py
@@ -673,6 +673,14 @@ def get_sqrtprec_from_sqrtprec(dim, sqrtprec, sparse_flag):
         logdet = np.sum(-np.log(precision))
         rank = dim
 
+    # sqrtprec is LinearOperator (only for RTOs)
+    elif isinstance(sqrtprec, spa.linalg.LinearOperator):
+        sqrtprec = sqrtprec
+        logdet
+        if hasattr(sqrtprec, 'logdet'):
+            logdet = sqrtprec.logdet
+        rank = dim
+
     # sqrtprec is full
     else:
         if spa.issparse(sqrtprec):

--- a/cuqi/distribution/_gaussian.py
+++ b/cuqi/distribution/_gaussian.py
@@ -191,7 +191,7 @@ class Gaussian(Distribution):
         value = force_ndarray(value)
         self._sqrtcov = value
         self._cov = None # Reset covariance (in case it was computed before)      
-        if (value is not None) and (not callable(value)):  
+        if (value is not None) and (not callable(value)): #TODO: problem here
             if self.dim > config.MIN_DIM_SPARSE:
                 sparse_flag = True # do sparse computations
             else:

--- a/cuqi/distribution/_gaussian.py
+++ b/cuqi/distribution/_gaussian.py
@@ -676,7 +676,6 @@ def get_sqrtprec_from_sqrtprec(dim, sqrtprec, sparse_flag):
     # sqrtprec is LinearOperator (only for RTOs)
     elif isinstance(sqrtprec, spa.linalg.LinearOperator):
         sqrtprec = sqrtprec
-        logdet
         if hasattr(sqrtprec, 'logdet'):
             logdet = sqrtprec.logdet
         rank = dim

--- a/cuqi/utilities/__init__.py
+++ b/cuqi/utilities/__init__.py
@@ -10,6 +10,7 @@ from ._utilities import (
     ProblemInfo,
     sparse_cholesky,
     approx_derivative,
+    check_if_conditional_from_attr,
 )
 
 from ._get_python_variable_name import _get_python_variable_name

--- a/cuqi/utilities/_utilities.py
+++ b/cuqi/utilities/_utilities.py
@@ -64,7 +64,7 @@ def get_indirect_variables(dist):
     attributes = []
     for attribute in dist.get_mutable_variables():
         value = getattr(dist, attribute)
-        if callable(value):
+        if callable(value) and not isinstance(value, spslinalg.LinearOperator):
             keys = get_non_default_args(value)
             for key in keys:
                 if key not in attributes: #Ensure we did not already find this key

--- a/cuqi/utilities/_utilities.py
+++ b/cuqi/utilities/_utilities.py
@@ -73,7 +73,7 @@ def get_indirect_variables(dist):
 
 def check_if_conditional_from_attr(value):
     """
-    Check if a distribution is a conditional from its attribute.
+    Check if a distribution is conditional from a given attribute.
     So far, we assume that a distribution is conditional if
     - the given attribute is a callable function and
     - the given attribute is not a LinearOperator.

--- a/cuqi/utilities/_utilities.py
+++ b/cuqi/utilities/_utilities.py
@@ -64,12 +64,20 @@ def get_indirect_variables(dist):
     attributes = []
     for attribute in dist.get_mutable_variables():
         value = getattr(dist, attribute)
-        if callable(value) and not isinstance(value, spslinalg.LinearOperator):
+        if check_if_conditional_from_attr(value):
             keys = get_non_default_args(value)
             for key in keys:
                 if key not in attributes: #Ensure we did not already find this key
                     attributes.append(key)
     return attributes 
+
+def check_if_conditional_from_attr(value):
+    if isinstance(value, spslinalg.LinearOperator):
+        return False
+    elif callable(value):
+        return True
+    else:
+        return False
 
 def get_writeable_attributes(dist):
     """ Get writeable attributes of object instance. """

--- a/cuqi/utilities/_utilities.py
+++ b/cuqi/utilities/_utilities.py
@@ -72,6 +72,12 @@ def get_indirect_variables(dist):
     return attributes 
 
 def check_if_conditional_from_attr(value):
+    """
+    Check if a distribution is a conditional from its attribute.
+    So far, we assume that a distribution is conditional if
+    - the given attribute is a callable function and
+    - the given attribute is not a LinearOperator.
+    """
     if isinstance(value, spslinalg.LinearOperator):
         return False
     elif callable(value):

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -738,3 +738,21 @@ def test_Gaussian_from_sparse_sqrtprec():
 
     assert y_from_dense.logpdf(np.ones(N)) == y_from_sparse.logpdf(np.ones(N))
 
+def test_Gaussian_from_linear_operator_sqrtprec():
+    """ Test Gaussian distribution from LinearOperator sqrtprec is equal to dense sqrtprec """
+    N = 10; M = 5
+
+    sqrtprec = sp.sparse.spdiags(np.random.randn(N), 0, N, N)
+
+    def matvec(x):
+        return sqrtprec @ x
+    def rmatvec(x):
+        return sqrtprec.T @ x
+    
+    sqrtprec_operator = sp.sparse.linalg.LinearOperator((N, N), matvec=matvec, rmatvec=rmatvec)
+    sqrtprec_operator.logdet=0
+
+    y_from_sparse = cuqi.distribution.Gaussian(mean = np.zeros(N), sqrtprec = sqrtprec_operator)
+    y_from_dense = cuqi.distribution.Gaussian(mean = np.zeros(N), sqrtprec = sqrtprec.todense())
+
+    assert y_from_dense.logpdf(np.ones(N)) == y_from_sparse.logpdf(np.ones(N))


### PR DESCRIPTION
fixed #419 

Issue: it might open some opportunities if we allow a Gaussian distribution to be initialized with `scipy.sparse.linalg.LinearOperator`. 

What I did:
- update `get_sqrtprec_from_sqrtcov` in `cuqi/distribution/_gaussian.py` to accept a`LinearOperator` object as `sqrtprec`;
- add `check_if_conditional_from_attr` in `cuqi/utilities/_utilities.py`, following @nabriis 's comment below;
- `check_if_conditional_from_attr` is used in `get_indirect_variables` so that a `Gaussian` distribution initialized with `LinearOperator` is not detected as a conditional distribution (just a reminder: a LinearOperator is callable);
- add unit test `test_Gaussian_from_linear_operator_sqrtprec` in `tests/test_distribution.py`

Some notes (please correct me if I'm wrong here):
- For MCMC methods in general, we don't need `logdet` as it will be cancelled when evaluating the density function of the proposal and the current state;
- In CUQIpy, we need `logdet` defined to compute `logpdf`: I think this is somehow unnecessary and the unnormalized version `_logupdf` should be enough in place of `logpdf`. But I have to admit that I'm _not confident_ if this point still holds when it comes to Gibbs sampling. (This issue turned out to be an echo from the old days #16, as Nicolai pointed in the comments below)
- In order to make a Gaussian distribution initialized with `LinearOperator` work with the current samplers in CUQIpy except ROTs, we need to set `logdet` to some value. It doesn't matter to what value it is set as it will be cancelled.
- For RTOs, we don't evaluate `logpdf`, so we don't need to set `logdet`.