### PR TITLE
Add SmoothedLaplace

### DIFF
--- a/cuqi/distribution/__init__.py
+++ b/cuqi/distribution/__init__.py
@@ -9,6 +9,7 @@ from ._gmrf import GMRF
 from ._inverse_gamma import InverseGamma
 from ._lmrf import LMRF
 from ._laplace import Laplace
+from ._smoothed_laplace import SmoothedLaplace
 from ._lognormal import Lognormal
 from ._normal import Normal
 from ._posterior import Posterior

--- a/cuqi/distribution/_smoothed_laplace.py
+++ b/cuqi/distribution/_smoothed_laplace.py
@@ -1,4 +1,5 @@
 import numpy as np
+from cuqi.utilities import force_ndarray
 from cuqi.distribution import Distribution
 
 class SmoothedLaplace(Distribution):
@@ -33,23 +34,36 @@ class SmoothedLaplace(Distribution):
     def __init__(self, location, scale, beta=1e-3, **kwargs):
         super().__init__(**kwargs)
 
-        # location accepts scalar, list, tuple, or ndarray
-        if isinstance(location, (float, int)):
-            self.location = np.array([location])
-        elif isinstance(location, (list, tuple)):
-            self.location = np.array(location)
-        else:
-            self.location = location
-
-        # scale accepts scalar, list, tuple, or ndarray
-        if isinstance(scale, (float, int)):
-            self.scale = np.array([scale])
-        elif isinstance(scale, (list, tuple)):
-            self.scale = np.array(scale)
-        else:
-            self.scale = scale
-
+        self.location = location
+        self.scale = scale
         self.beta = beta
+
+    @property
+    def location(self):
+        """ Location parameter """
+        return self._location
+    
+    @location.setter
+    def location(self, value):
+        self._location = force_ndarray(value, flatten=True)
+
+    @property
+    def scale(self):
+        """ Scale parameter """
+        return self._scale
+    
+    @scale.setter
+    def scale(self, value):
+        self._scale = force_ndarray(value, flatten=True)
+
+    @property
+    def beta(self):
+        """ Beta parameter """
+        return self._beta
+    
+    @beta.setter
+    def beta(self, value):
+        self._beta = value
 
     def logpdf(self, x):
         """

--- a/cuqi/distribution/_smoothed_laplace.py
+++ b/cuqi/distribution/_smoothed_laplace.py
@@ -54,12 +54,6 @@ class SmoothedLaplace(Distribution):
     def logpdf(self, x):
         """
         Computes the logarithm of the probability density function at the given values of x.
-
-        Parameters:
-            x (float, int, list, tuple, or ndarray): The values at which to compute the logarithm of the probability density function.
-
-        Returns:
-            float, ndarray: The logarithm of the probability density function evaluated at x.
         """
         # x accepts scalar, list, tuple, or ndarray
         if isinstance(x, (float, int)):
@@ -71,12 +65,6 @@ class SmoothedLaplace(Distribution):
     def gradient(self, x):
         """
         Computes the gradient of the distribution at the given values of x.
-
-        Parameters:
-            x (float, int, list, tuple, or ndarray): The values at which to compute the gradient.
-
-        Returns:
-            ndarray: The gradient of the distribution evaluated at x.
         """
         # x accepts scalar, list, tuple, or ndarray
         if isinstance(x, (float, int)):
@@ -88,12 +76,5 @@ class SmoothedLaplace(Distribution):
     def _sample(self, N=1, rng=None):
         """
         Generates random samples from the distribution.
-
-        Parameters:
-            N (int, optional): The number of samples to generate. Default is 1.
-            rng (RandomState, optional): The random number generator to use. Default is None.
-
-        Raises:
-            NotImplementedError: This method is not implemented for the SmoothedLaplace class.
         """
         raise NotImplementedError(f"sample is not implemented for {self.__class__.__name__}.")

--- a/cuqi/distribution/_smoothed_laplace.py
+++ b/cuqi/distribution/_smoothed_laplace.py
@@ -1,0 +1,99 @@
+import numpy as np
+from cuqi.distribution import Distribution
+
+class SmoothedLaplace(Distribution):
+    """ Laplace distribution. 
+
+    Defines a smoothed Laplace distribution given a location, a scale and a smoothing parameter
+    beta. The smoothed Laplace distribution is defined as
+
+    .. math::
+
+        p(x) = \\frac{1}{2b} \exp\left(-\\frac{\sqrt{(x-\mu)^2 + \beta}}{b}\\right),
+
+    where :math:`\mu` is the location (mean), :math:`b` is the scale (decay) parameter and
+    :math:`\beta` is the smoothing parameter.
+
+    The rate parameter is defined as :math:`\lambda = \\frac{1}{b}`.
+
+    The variables of this Laplace distribution are independent identically distributed (i.i.d.).
+
+    Parameters
+    ----------
+    location : scalar, list, tuple, or ndarray
+        The location parameter of the distribution.
+
+    scale : scalar, list, tuple, or ndarray
+        The scale parameter of the distribution.
+    
+    beta : scalar
+
+    """
+
+    def __init__(self, location, scale, beta=1e-3, **kwargs):
+        super().__init__(**kwargs)
+
+        # location accepts scalar, list, tuple, or ndarray
+        if isinstance(location, (float, int)):
+            self.location = np.array([location])
+        elif isinstance(location, (list, tuple)):
+            self.location = np.array(location)
+        else:
+            self.location = location
+
+        # scale accepts scalar, list, tuple, or ndarray
+        if isinstance(scale, (float, int)):
+            self.scale = np.array([scale])
+        elif isinstance(scale, (list, tuple)):
+            self.scale = np.array(scale)
+        else:
+            self.scale = scale
+
+        self.beta = beta
+
+    def logpdf(self, x):
+        """
+        Computes the logarithm of the probability density function at the given values of x.
+
+        Parameters:
+            x (float, int, list, tuple, or ndarray): The values at which to compute the logarithm of the probability density function.
+
+        Returns:
+            float, ndarray: The logarithm of the probability density function evaluated at x.
+        """
+        # x accepts scalar, list, tuple, or ndarray
+        if isinstance(x, (float, int)):
+            x = np.array([x])
+        elif isinstance(x, (list, tuple)):
+            x = np.array(x)
+        return np.sum(np.log(0.5 / self.scale)) - np.sum(np.sqrt((x - self.location) ** 2 + self.beta) / self.scale)
+
+    def gradient(self, x):
+        """
+        Computes the gradient of the distribution at the given values of x.
+
+        Parameters:
+            x (float, int, list, tuple, or ndarray): The values at which to compute the gradient.
+
+        Returns:
+            ndarray: The gradient of the distribution evaluated at x.
+        """
+        # x accepts scalar, list, tuple, or ndarray
+        if isinstance(x, (float, int)):
+            x = np.array([x])
+        elif isinstance(x, (list, tuple)):
+            x = np.array(x)
+        return -np.array((x - self.location) / self.scale / np.sqrt((x - self.location) ** 2 + self.beta))
+
+    def _sample(self, N=1, rng=None):
+        """
+        Generates random samples from the distribution.
+
+        Parameters:
+            N (int, optional): The number of samples to generate. Default is 1.
+            rng (RandomState, optional): The random number generator to use. Default is None.
+
+        Raises:
+            NotImplementedError: This method is not implemented for the SmoothedLaplace class.
+        """
+        raise NotImplementedError(f"sample is not implemented for {self.__class__.__name__}.")

--- a/cuqi/distribution/_smoothed_laplace.py
+++ b/cuqi/distribution/_smoothed_laplace.py
@@ -64,7 +64,7 @@ class SmoothedLaplace(Distribution):
 
     def gradient(self, x):
         """
-        Computes the gradient of the distribution at the given values of x.
+        Computes the gradient of logpdf at the given values of x.
         """
         # x accepts scalar, list, tuple, or ndarray
         if isinstance(x, (float, int)):

--- a/cuqi/distribution/_smoothed_laplace.py
+++ b/cuqi/distribution/_smoothed_laplace.py
@@ -2,7 +2,7 @@ import numpy as np
 from cuqi.distribution import Distribution
 
 class SmoothedLaplace(Distribution):
-    """ Laplace distribution. 
+    """ Smoothed Laplace distribution. 
 
     Defines a smoothed Laplace distribution given a location, a scale and a smoothing parameter
     beta. The smoothed Laplace distribution is defined as

--- a/cuqi/distribution/_smoothed_laplace.py
+++ b/cuqi/distribution/_smoothed_laplace.py
@@ -28,6 +28,7 @@ class SmoothedLaplace(Distribution):
         The scale parameter of the distribution.
     
     beta : scalar
+        The smoothing parameter of the distribution.
 
     """
 

--- a/cuqi/distribution/_smoothed_laplace.py
+++ b/cuqi/distribution/_smoothed_laplace.py
@@ -31,7 +31,7 @@ class SmoothedLaplace(Distribution):
 
     """
 
-    def __init__(self, location, scale, beta=1e-3, **kwargs):
+    def __init__(self, location=None, scale=None, beta=1e-3, **kwargs):
         super().__init__(**kwargs)
 
         self.location = location

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -786,7 +786,7 @@ def test_Smoothed_Laplace():
 
     location = np.array([1, 2])
     scale = np.array([1, 2])
-    scaller_laplace_0 = cuqi.distribution.Laplace(location[0], scale[0])
+    scalar_laplace_0 = cuqi.distribution.Laplace(location[0], scale[0])
 
     scalar_smoothed_laplace_0 = cuqi.distribution.SmoothedLaplace(location[0], scale[0], 1e-8)
     scalar_smoothed_laplace_1 = cuqi.distribution.SmoothedLaplace(location[1], scale[1], 1e-8)
@@ -795,7 +795,7 @@ def test_Smoothed_Laplace():
     x = np.array([3, 4])
 
     # logpdf (scalar Laplace vs scalar Smoothed Laplace)
-    assert np.allclose(scaller_laplace_0.logpdf([x[0]]), scalar_smoothed_laplace_0.logpdf(x[0]))
+    assert np.allclose(scalar_laplace_0.logpdf([x[0]]), scalar_smoothed_laplace_0.logpdf(x[0]))
 
     # logpdf (scalar Smoothed Laplace * scalar Smoothed Laplace vs vector Smoothed Laplace)
     assert np.allclose(scalar_smoothed_laplace_0.logpdf(x[0])+scalar_smoothed_laplace_1.logpdf(x[1]),

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -780,3 +780,29 @@ def test_MHN_regression(alpha, beta, gamma, expected_logpdf, expected_gradient):
     gradient = dist._gradient(np.array([1.0, 2.0, 3.0, 4.0, 5.0]))
     assert np.allclose( logpdf, np.array(expected_logpdf))
     assert np.allclose( gradient, np.array(expected_gradient))
+
+def test_Smoothed_Laplace():
+    """ Test Smoothed Laplace distribution logpdf, cdf, pdf, gradient """
+
+    location = np.array([1, 2])
+    scale = np.array([1, 2])
+    scaller_laplace_0 = cuqi.distribution.Laplace(location[0], scale[0])
+
+    scalar_smoothed_laplace_0 = cuqi.distribution.SmoothedLaplace(location[0], scale[0], 1e-8)
+    scalar_smoothed_laplace_1 = cuqi.distribution.SmoothedLaplace(location[1], scale[1], 1e-8)
+    vector_smoothed_laplace = cuqi.distribution.SmoothedLaplace(location, scale, 1e-6)
+
+    x = np.array([3, 4])
+
+    # logpdf (scalar Laplace vs scalar Smoothed Laplace)
+    assert np.allclose(scaller_laplace_0.logpdf([x[0]]), scalar_smoothed_laplace_0.logpdf(x[0]))
+
+    # logpdf (scalar smoothed Laplace * scalar smoothed Laplace vs vector smoothed Laplace)
+    assert np.allclose(scalar_smoothed_laplace_0.logpdf(x[0])+scalar_smoothed_laplace_1.logpdf(x[1]),
+                       vector_smoothed_laplace.logpdf(x))
+    
+    # gradient (scalar Smoothed Laplace vs analytical)
+    assert np.allclose(scalar_smoothed_laplace_0.gradient(x[0]), -1/scale[0])
+
+    # gradient (vector Smoothed Laplace vs analytical)
+    assert np.allclose(vector_smoothed_laplace.gradient(x), -1/scale)

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -797,7 +797,7 @@ def test_Smoothed_Laplace():
     # logpdf (scalar Laplace vs scalar Smoothed Laplace)
     assert np.allclose(scaller_laplace_0.logpdf([x[0]]), scalar_smoothed_laplace_0.logpdf(x[0]))
 
-    # logpdf (scalar smoothed Laplace * scalar smoothed Laplace vs vector smoothed Laplace)
+    # logpdf (scalar Smoothed Laplace * scalar Smoothed Laplace vs vector Smoothed Laplace)
     assert np.allclose(scalar_smoothed_laplace_0.logpdf(x[0])+scalar_smoothed_laplace_1.logpdf(x[1]),
                        vector_smoothed_laplace.logpdf(x))
     

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -782,7 +782,7 @@ def test_MHN_regression(alpha, beta, gamma, expected_logpdf, expected_gradient):
     assert np.allclose( gradient, np.array(expected_gradient))
 
 def test_Smoothed_Laplace():
-    """ Test Smoothed Laplace distribution logpdf, cdf, pdf, gradient """
+    """ Test Smoothed Laplace distribution logpdf and gradient """
 
     location = np.array([1, 2])
     scale = np.array([1, 2])
@@ -790,7 +790,7 @@ def test_Smoothed_Laplace():
 
     scalar_smoothed_laplace_0 = cuqi.distribution.SmoothedLaplace(location[0], scale[0], 1e-8)
     scalar_smoothed_laplace_1 = cuqi.distribution.SmoothedLaplace(location[1], scale[1], 1e-8)
-    vector_smoothed_laplace = cuqi.distribution.SmoothedLaplace(location, scale, 1e-6)
+    vector_smoothed_laplace = cuqi.distribution.SmoothedLaplace(location, scale, 1e-8)
 
     x = np.array([3, 4])
 


### PR DESCRIPTION
fixed #451 

This PR adds SmoothedLaplace, an approximation of Laplace, and its pdf is evaluated as 
$$p(x) = \frac{1}{2b} \exp\left(-\frac{\sqrt{(x-\mu)^2 + \beta}}{b}\right),$$
where $\beta$ is a smoothing parameter.

Compared with Laplace, SmoothedLaplace comes with a `gradient` method and it enables the use of gradient-based samplers.

Smoothed Laplace was implemented earlier as a custom distribution in showcase notebooks on [smoothed Laplace](https://github.com/CUQI-DTU/CUQIpy-User-Showcase/blob/main/007_smoothed_Laplace/smoothed_laplace.ipynb) and [super resolution](https://github.com/CUQI-DTU/CUQIpy-User-Showcase/blob/main/012_super_resolution/STORM.ipynb).