### PR TITLE
Add repr method for cuqi samples

### DIFF
--- a/cuqi/geometry/_geometry.py
+++ b/cuqi/geometry/_geometry.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 import numpy as np
 import numpy.matlib as matlib
 import matplotlib.pyplot as plt
-from matplotlib.ticker import MaxNLocator
 import math
 from scipy.fftpack import dst, idst
 import scipy.sparse as sparse

--- a/cuqi/geometry/_geometry.py
+++ b/cuqi/geometry/_geometry.py
@@ -410,6 +410,7 @@ class Continuous1D(Continuous):
         if self.axis_labels is not None:
             plt.xlabel(self.axis_labels[0])
 
+
 class Continuous2D(Continuous):
 
     def __init__(self,grid=None,axis_labels=None):

--- a/cuqi/geometry/_geometry.py
+++ b/cuqi/geometry/_geometry.py
@@ -410,8 +410,6 @@ class Continuous1D(Continuous):
     def _plot_config(self):
         if self.axis_labels is not None:
             plt.xlabel(self.axis_labels[0])
-        plt.gca().xaxis.set_major_locator(MaxNLocator(integer=True))
-
 
 class Continuous2D(Continuous):
 

--- a/cuqi/geometry/_geometry.py
+++ b/cuqi/geometry/_geometry.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 import numpy as np
 import numpy.matlib as matlib
 import matplotlib.pyplot as plt
+from matplotlib.ticker import MaxNLocator
 import math
 from scipy.fftpack import dst, idst
 import scipy.sparse as sparse
@@ -409,6 +410,7 @@ class Continuous1D(Continuous):
     def _plot_config(self):
         if self.axis_labels is not None:
             plt.xlabel(self.axis_labels[0])
+        plt.gca().xaxis.set_major_locator(MaxNLocator(integer=True))
 
 
 class Continuous2D(Continuous):

--- a/cuqi/samples/_samples.py
+++ b/cuqi/samples/_samples.py
@@ -874,8 +874,6 @@ class Samples(object):
 
         return ax
 
-    def __repr__(self) -> str:
-        return f"A CUQIpy Samples object containging {self.Ns} samples, each of length {self.geometry.par_dim}."
     def __repr__(self) -> str: 
         return "CUQIpy Samples:\n" + \
                "---------------\n\n" + \

--- a/cuqi/samples/_samples.py
+++ b/cuqi/samples/_samples.py
@@ -876,3 +876,10 @@ class Samples(object):
 
     def __repr__(self) -> str:
         return f"A CUQIpy Samples object containging {self.Ns} samples, each of length {self.geometry.par_dim}."
+    def __repr__(self) -> str: 
+        return "CUQIpy Samples:\n" + \
+               "---------------\n\n" + \
+               "Ns (number of samples):\n {}\n\n".format(self.Ns) + \
+               "Geometry:\n {}\n\n".format(self.geometry) + \
+               "Shape:\n {}\n\n".format(self.shape) + \
+               "Samples:\n {}\n\n".format(self.samples)

--- a/cuqi/samples/_samples.py
+++ b/cuqi/samples/_samples.py
@@ -875,4 +875,4 @@ class Samples(object):
         return ax
 
     def __repr__(self) -> str:
-        return "A CUQIpy samples object with shape {}".format(self.samples.shape)
+        return f"A CUQIpy samples object containging {self.Ns} samples, each of length {self.samples.shape[1]}."

--- a/cuqi/samples/_samples.py
+++ b/cuqi/samples/_samples.py
@@ -875,4 +875,4 @@ class Samples(object):
         return ax
 
     def __repr__(self) -> str:
-        return f"A CUQIpy samples object containging {self.Ns} samples, each of length {self.geometry.par_dim}."
+        return f"A CUQIpy Samples object containging {self.Ns} samples, each of length {self.geometry.par_dim}."

--- a/cuqi/samples/_samples.py
+++ b/cuqi/samples/_samples.py
@@ -873,3 +873,6 @@ class Samples(object):
         ax =  arviz.plot_violin(datadict, **kwargs)
 
         return ax
+
+    def __repr__(self) -> str:
+        return "A CUQIpy samples object with shape {}".format(self.samples.shape)

--- a/cuqi/samples/_samples.py
+++ b/cuqi/samples/_samples.py
@@ -875,4 +875,4 @@ class Samples(object):
         return ax
 
     def __repr__(self) -> str:
-        return f"A CUQIpy samples object containging {self.Ns} samples, each of length {self.samples.shape[1]}."
+        return f"A CUQIpy samples object containging {self.Ns} samples, each of length {self.geometry.par_dim}."


### PR DESCRIPTION
- fixed #468

Now when we `evaluate/print` a cuqi Samples, it will display something like:
```bash
CUQIpy Samples:
---------------

Ns (number of samples):
 2

Geometry:
 _DefaultGeometry1D(4,)

Shape:
 (4, 2)

Samples:
 [[ 1.38560564  0.53052923]
 [ 0.4737199   0.51313651]
 [-0.20398077 -1.29972158]
 [-2.48091298  0.27251739]]
```
