### PR TITLE
update installation instructions and use with vscode

### DIFF
--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -37,7 +37,7 @@ Then to activate the environment:
 
 .. code-block:: sh
 
-   conda activate cuqipy
+   conda activate cuqipy-env
 
 Then install CUQIpy and all its dependencies in the activated environment `cuqipy-env`:
 

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -134,7 +134,7 @@ Then run the tests from the terminal (Linux or Mac) or Anaconda Prompt (Windows)
 Working with VS Code (optional)
 -------------------------------
 
-To improve your coding experience with Python in VS Code, you might want to install the |Python-extension| and |Jupyter-extension| extensions in VS Code. In VS Code, don't forget to select a Python interpreter in the environment that CUQIpy is installed. More information on how to work with Python in VS Code can be found |Python-VSCode|.
+To improve your coding experience with Python in VS Code, we recommend installing the |Python-extension| and |Jupyter-extension| extensions in VS Code. In VS Code, don't forget to select the Python interpreter of the environment in which CUQIpy is installed, `cuqipy` in this case. More information on how to work with Python in VS Code can be found |Python-VSCode|.
 
 .. |Python-extension| raw:: html
 

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -23,7 +23,19 @@ easily be installed through anaconda.
 Installation
 ------------
 
-Installing CUQIpy is easy. Open your terminal (Linux and Mac) or Anaconda Prompt (Windows) and install it using pip:
+Before installing CUQIpy, We highly recommend creating a new Python environment using conda. This will ensure that CUQIpy's dependencies do not interfere with other Python packages you may have installed. Additinally, we also install pip in the environment.
+
+.. code-block:: sh
+
+   conda create -n cuqipy-env pip
+
+Activate the environment:
+
+.. code-block:: sh
+
+   conda activate cuqipy-env
+
+Then install CUQIpy and all its dependencies:
 
 .. code-block:: sh
 
@@ -106,3 +118,8 @@ Then run the tests from the terminal (Linux or Mac) or Anaconda Prompt (Windows)
 .. code-block:: sh
 
    python -m pytest -v
+
+Working with VS Code (optional)
+-------------------------------
+
+To improve your coding experience with Python in VS Code, you might want to install the [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python) and [Jupyter](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter) extensions in VS Code. In VS Code, don't forget to select a Python interpreter in the environment that CUQIpy is installed. More information on how to work with Python in VS Code can be found [here](https://code.visualstudio.com/docs/languages/python).

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -40,7 +40,7 @@ Then to activate the environment:
 
    conda activate cuqipy
 
-Then install CUQIpy and all its dependencies:
+Then install CUQIpy and all its dependencies in the activated environment `cuqipy`:
 
 .. code-block:: sh
 

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -48,7 +48,7 @@ Then install CUQIpy and all its dependencies:
 
 This will install the latest version of CUQIpy and all its dependencies.
 
-It is also suggested to install ipykernel as we usually work with jupyter notebooks a lot:
+We also suggest installing ipykernel to be able to run `cuqipy` jupyter notebook examples:
 
 .. code-block:: sh
 

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -34,7 +34,7 @@ Before installing CUQIpy, We highly recommend creating a new Python environment 
 
    conda create -n cuqipy pip
 
-Activate the environment:
+Then to activate the environment:
 
 .. code-block:: sh
 

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -14,8 +14,7 @@ We recommend installing python via the anaconda distribution:
 
    <a href="https://www.anaconda.com/products/distribution" target="_blank">Anaconda distribution</a>
 
-Anaconda comes with many useful python libraries pre-installed and makes it easy to run CUQIpy code
-via the jupyter notebook app. In addition, CUQIpy plugins often require 3rd party libraries that can most
+Anaconda comes with many useful python libraries pre-installed and makes it easy to run CUQIpy code via the jupyter notebook app. In addition, CUQIpy plugins often require 3rd party libraries that can most
 easily be installed through anaconda. |Miniconda| is a lightweight alternative to Anaconda if storage is a concern.
 
 .. |Miniconda| raw:: html
@@ -28,11 +27,11 @@ easily be installed through anaconda. |Miniconda| is a lightweight alternative t
 Installation
 ------------
 
-Before installing CUQIpy, We highly recommend creating a new Python environment using conda. This will ensure that CUQIpy's dependencies do not interfere with other Python packages you may have installed. Here we choose `cuqipy` as the environment's name and also install pip in it with the following command
+Before installing CUQIpy, We highly recommend creating a new Python environment using conda. This will ensure that CUQIpy's dependencies do not interfere with other Python packages you may have installed. Here we choose `cuqipy-env` as the environment's name and also install pip in it with the following command
 
 .. code-block:: sh
 
-   conda create -n cuqipy pip
+   conda create -n cuqipy-env pip
 
 Then to activate the environment:
 
@@ -40,7 +39,7 @@ Then to activate the environment:
 
    conda activate cuqipy
 
-Then install CUQIpy and all its dependencies in the activated environment `cuqipy`:
+Then install CUQIpy and all its dependencies in the activated environment `cuqipy-env`:
 
 .. code-block:: sh
 
@@ -48,7 +47,7 @@ Then install CUQIpy and all its dependencies in the activated environment `cuqip
 
 This will install the latest version of CUQIpy and all its dependencies.
 
-We also suggest installing ipykernel to be able to run `cuqipy` jupyter notebook examples:
+We also suggest installing ipykernel to be able to run CUQIpy jupyter notebook examples:
 
 .. code-block:: sh
 
@@ -134,7 +133,7 @@ Then run the tests from the terminal (Linux or Mac) or Anaconda Prompt (Windows)
 Working with VS Code (optional)
 -------------------------------
 
-To improve your coding experience with Python in VS Code, we recommend installing the |Python-extension| and |Jupyter-extension| extensions in VS Code. In VS Code, don't forget to select the Python interpreter of the environment in which CUQIpy is installed, `cuqipy` in this case. More information on how to work with Python in VS Code can be found |Python-VSCode|.
+To improve your coding experience with Python in VS Code, we recommend installing the |Python-extension| and |Jupyter-extension| extensions in VS Code. In VS Code, don't forget to select the Python interpreter of the environment in which CUQIpy is installed, `cuqipy-env` in this case. More information on how to work with Python in VS Code can be found |Python-VSCode|.
 
 .. |Python-extension| raw:: html
 

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -134,16 +134,16 @@ Then run the tests from the terminal (Linux or Mac) or Anaconda Prompt (Windows)
 Working with VS Code (optional)
 -------------------------------
 
-To improve your coding experience with Python in VS Code, you might want to install the |Python-extension| and |Jupyter-extension| extensions in VS Code. In VS Code, don't forget to select a Python interpreter in the environment that CUQIpy is installed. More information on how to work with Python in VS Code can be found |Python-setup-VSCode|(https://code.visualstudio.com/docs/languages/python).
+To improve your coding experience with Python in VS Code, you might want to install the |Python-extension| and |Jupyter-extension| extensions in VS Code. In VS Code, don't forget to select a Python interpreter in the environment that CUQIpy is installed. More information on how to work with Python in VS Code can be found |Python-VSCode|.
 
 .. |Python-extension| raw:: html
 
-   <a href="https://marketplace.visualstudio.com/items?itemName=ms-python.python" target="_blank">Python extension</a>
+   <a href="https://marketplace.visualstudio.com/items?itemName=ms-python.python" target="_blank">Python</a>
 
 .. |Jupyter-extension| raw:: html
 
-   <a href="https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter" target="_blank">Jupyter extension</a>
+   <a href="https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter" target="_blank">Jupyter</a>
 
-.. |Python-setup-VSCode| raw:: html
+.. |Python-VSCode| raw:: html
 
-   <a href="https://code.visualstudio.com/docs/languages/python" target="_blank">Python in VS Code</a>
+   <a href="https://code.visualstudio.com/docs/languages/python" target="_blank">here</a>

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -16,24 +16,29 @@ We recommend installing python via the anaconda distribution:
 
 Anaconda comes with many useful python libraries pre-installed and makes it easy to run CUQIpy code
 via the jupyter notebook app. In addition, CUQIpy plugins often require 3rd party libraries that can most
-easily be installed through anaconda.
+easily be installed through anaconda. |Miniconda| is a lightweight alternative to Anaconda if storage is a concern.
+
+.. |Miniconda| raw:: html
+
+   <a href="https://docs.anaconda.com/miniconda/miniconda-install/" target="_blank">Miniconda</a>
+
 
 .. _install:
 
 Installation
 ------------
 
-Before installing CUQIpy, We highly recommend creating a new Python environment using conda. This will ensure that CUQIpy's dependencies do not interfere with other Python packages you may have installed. Additinally, we also install pip in the environment.
+Before installing CUQIpy, We highly recommend creating a new Python environment using conda. This will ensure that CUQIpy's dependencies do not interfere with other Python packages you may have installed. Here we choose `cuqipy` as the environment's name and also install pip in it.
 
 .. code-block:: sh
 
-   conda create -n cuqipy-env pip
+   conda create -n cuqipy pip
 
 Activate the environment:
 
 .. code-block:: sh
 
-   conda activate cuqipy-env
+   conda activate cuqipy
 
 Then install CUQIpy and all its dependencies:
 
@@ -42,6 +47,13 @@ Then install CUQIpy and all its dependencies:
    pip install cuqipy
 
 This will install the latest version of CUQIpy and all its dependencies.
+
+It is also suggested to install ipykernel as we usually work with jupyter notebooks a lot:
+
+.. code-block:: sh
+
+   pip install ipykernel
+
 
 Verification
 ------------
@@ -122,4 +134,16 @@ Then run the tests from the terminal (Linux or Mac) or Anaconda Prompt (Windows)
 Working with VS Code (optional)
 -------------------------------
 
-To improve your coding experience with Python in VS Code, you might want to install the [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python) and [Jupyter](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter) extensions in VS Code. In VS Code, don't forget to select a Python interpreter in the environment that CUQIpy is installed. More information on how to work with Python in VS Code can be found [here](https://code.visualstudio.com/docs/languages/python).
+To improve your coding experience with Python in VS Code, you might want to install the |Python-extension| and |Jupyter-extension| extensions in VS Code. In VS Code, don't forget to select a Python interpreter in the environment that CUQIpy is installed. More information on how to work with Python in VS Code can be found |Python-setup-VSCode|(https://code.visualstudio.com/docs/languages/python).
+
+.. |Python-extension| raw:: html
+
+   <a href="https://marketplace.visualstudio.com/items?itemName=ms-python.python" target="_blank">Python extension</a>
+
+.. |Jupyter-extension| raw:: html
+
+   <a href="https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter" target="_blank">Jupyter extension</a>
+
+.. |Python-setup-VSCode| raw:: html
+
+   <a href="https://code.visualstudio.com/docs/languages/python" target="_blank">Python in VS Code</a>

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -28,7 +28,7 @@ easily be installed through anaconda. |Miniconda| is a lightweight alternative t
 Installation
 ------------
 
-Before installing CUQIpy, We highly recommend creating a new Python environment using conda. This will ensure that CUQIpy's dependencies do not interfere with other Python packages you may have installed. Here we choose `cuqipy` as the environment's name and also install pip in it.
+Before installing CUQIpy, We highly recommend creating a new Python environment using conda. This will ensure that CUQIpy's dependencies do not interfere with other Python packages you may have installed. Here we choose `cuqipy` as the environment's name and also install pip in it with the following command
 
 .. code-block:: sh
 


### PR DESCRIPTION
fixed #471 

Some notes:
## Regarding anaconda
__Question__: Anaconda is quite heavy and should we suggest using miniconda in the installing instructions?
- it comes with many default libraries that we won't use if we create an environment.
- it takes several minutes to install on my machine
- it takes  around 8GB of storage as a fresh installation while miniconda takes 450 MB
A comparison between anaconda and miniconda is here https://docs.anaconda.com/distro-or-miniconda/ .

## Regarding jupyter-lab/notebook, __NO__ question here, just for your reference
jupyter-lab and -notebook come with anaconda by default.
- in the default environment/termial, the user is able to start jupyter-lab/notebook, but the cuqi-env environment doesn't show as an available kernel. 
- in the user-created `cuqi-env` environment, the user is not able to start jupyter-lab/notebook (as it's not installed to this environment)

## Regarding VS Code, __NO__ question here, just for your reference
In order to run/debug python and jupyter notebooks in vscode, the user needs to install two vscode extensions: Python and Jupyter, and one package `ipykernel` which can be installed either via pip explicitly by the user or after the warning in vscode after selecting a kernel.

