### PR TITLE
Replace progressbar2 by tqdm

### DIFF
--- a/cuqi/experimental/mcmc/_gibbs.py
+++ b/cuqi/experimental/mcmc/_gibbs.py
@@ -6,10 +6,10 @@ import numpy as np
 import warnings
 
 try:
-    from progressbar import progressbar
+    from tqdm import tqdm
 except ImportError:
-    def progressbar(iterable, **kwargs):
-        warnings.warn("Module mcmc: Progressbar not found. Install progressbar2 to get sampling progress.")
+    def tqdm(iterable, **kwargs):
+        warnings.warn("Module mcmc: tqdm not found. Install tqdm to get sampling progress.")
         return iterable
 
 # Not subclassed from Sampler as Gibbs handles multiple samplers and samples multiple parameters
@@ -152,13 +152,13 @@ class HybridGibbs:
 
     def sample(self, Ns) -> 'HybridGibbs':
         """ Sample from the joint distribution using Gibbs sampling """
-        for _ in progressbar(range(Ns)):
+        for _ in tqdm(range(Ns)):
             self.step()
             self._store_samples()
 
     def warmup(self, Nb) -> 'HybridGibbs':
         """ Warmup (tune) the Gibbs sampler """
-        for idx in progressbar(range(Nb)):
+        for idx in tqdm(range(Nb)):
             self.step()
             self.tune(idx)
             self._store_samples()

--- a/cuqi/experimental/mcmc/_sampler.py
+++ b/cuqi/experimental/mcmc/_sampler.py
@@ -7,10 +7,10 @@ import cuqi
 from cuqi.samples import Samples
 
 try:
-    from progressbar import progressbar
+    from tqdm import tqdm
 except ImportError:
-    def progressbar(iterable, **kwargs):
-        warnings.warn("Module mcmc: Progressbar not found. Install progressbar2 to get sampling progress.")
+    def tqdm(iterable, **kwargs):
+        warnings.warn("Module mcmc: tqdm not found. Install tqdm to get sampling progress.")
         return iterable
 
 class Sampler(ABC):
@@ -220,7 +220,7 @@ class Sampler(ABC):
         if hasattr(self, "_pre_sample"): self._pre_sample()
 
         # Draw samples
-        for _ in progressbar( range(Ns) ):
+        for _ in tqdm( range(Ns) ):
             
             # Perform one step of the sampler
             acc = self.step()
@@ -260,7 +260,7 @@ class Sampler(ABC):
         if hasattr(self, "_pre_warmup"): self._pre_warmup()
 
         # Draw warmup samples with tuning
-        for idx in progressbar(range(Nb)):
+        for idx in tqdm(range(Nb)):
 
             # Perform one step of the sampler
             acc = self.step()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,4 @@ sphinx-panels
 sphinx-copybutton
 sphinx-gallery
 versioneer==0.26
-progressbar2 # For experimental mcmc module
+tqdm # For experimental mcmc module


### PR DESCRIPTION
fixed #501 
## Issue:
`progressbar2` has display issues in jupyter notebooks where its progress information can easily span several pages. For example, `sampler.sample(200)` will give a screen output like the following
```bash
  0% (0 of 200) |                        | Elapsed Time: 0:00:00 ETA:  --:--:--
  0% (1 of 200) |                        | Elapsed Time: 0:00:00 ETA:   0:00:28
  2% (4 of 200) |                        | Elapsed Time: 0:00:00 ETA:   0:00:14
  2% (5 of 200) |                        | Elapsed Time: 0:00:00 ETA:   0:00:36
  3% (6 of 200) |                        | Elapsed Time: 0:00:01 ETA:   0:00:39
  3% (7 of 200) |                        | Elapsed Time: 0:00:01 ETA:   0:00:36
  4% (8 of 200) |                        | Elapsed Time: 0:00:01 ETA:   0:00:36
  5% (10 of 200) |#                      | Elapsed Time: 0:00:01 ETA:   0:00:29
  5% (11 of 200) |#                      | Elapsed Time: 0:00:01 ETA:   0:00:29

... many lines of display, omitted here (note by Charlie)

 97% (194 of 200) |##################### | Elapsed Time: 0:00:35 ETA:   0:00:00
 97% (195 of 200) |##################### | Elapsed Time: 0:00:35 ETA:   0:00:00
 98% (196 of 200) |##################### | Elapsed Time: 0:00:35 ETA:   0:00:00
 98% (197 of 200) |##################### | Elapsed Time: 0:00:35 ETA:   0:00:00
 99% (198 of 200) |##################### | Elapsed Time: 0:00:35 ETA:   0:00:00
 99% (199 of 200) |##################### | Elapsed Time: 0:00:36 ETA:   0:00:00
100% (200 of 200) |######################| Elapsed Time: 0:00:36 Time:  0:00:36
```
## Solution:
`tqdm` is a package that works similarly to `progressbar2` but does not suffer the above-described display problem.

With `tqdm`, the same line displaying the progress information will be dynamically updated (as expected).
```bash
100%|██████████| 200/200 [00:02<00:00, 68.48it/s]
```