### PR TITLE
Update documentation

### DIFF
--- a/cuqi/array/_array.py
+++ b/cuqi/array/_array.py
@@ -15,19 +15,7 @@ class CUQIarray(np.ndarray):
         Boolean flag whether input_array is to be interpreted as parameter (True) or function values (False).
 
     geometry : cuqi.geometry.Geometry, default None
-        Contains the geometry related of the data
-
-    Attributes
-    ----------
-    funvals : CUQIarray
-        Returns itself as function values.
-
-    parameters : CUQIarray
-        Returns itself as parameters.
-
-    Methods
-    ----------
-    :meth:`plot`: Plots the data as function or parameters.
+        Contains the geometry related of the data.
     """
 
     def __repr__(self) -> str: 
@@ -62,6 +50,7 @@ class CUQIarray(np.ndarray):
 
     @property
     def funvals(self):
+        """ Returns itself as function values. """
         if self.is_par is True:
             vals = self.geometry.par2fun(self)
         else:
@@ -82,6 +71,7 @@ class CUQIarray(np.ndarray):
 
     @property
     def parameters(self):
+        """ Returns itself as parameters. """
         if self.is_par is False:
             if self.dtype == np.dtype('O'):
                 # If the current state if the CUQIarray is function values, and
@@ -109,6 +99,7 @@ class CUQIarray(np.ndarray):
                 f"Cannot convert {self.__class__.__name__} to numpy array")
 
     def plot(self, plot_par=False, **kwargs):
+        """ Plot the data as function or parameters. """
         if plot_par:
             kwargs["is_par"]=True
             return self.geometry.plot(self.parameters, plot_par=plot_par, **kwargs)

--- a/cuqi/distribution/_beta.py
+++ b/cuqi/distribution/_beta.py
@@ -11,7 +11,7 @@ class Beta(Distribution):
 
     .. math::
 
-        f(x) = x^{(\alpha-1)}(1-x)^{(\beta-1)}\Gamma(\alpha+\beta) / (\Gamma(\alpha)\Gamma(\beta))
+        f(x) = x^{(\\alpha-1)}(1-x)^{(\\beta-1)}\Gamma(\\alpha+\\beta) / (\Gamma(\\alpha)\Gamma(\\beta))
 
     where :math:`\Gamma` is the Gamma function.
 

--- a/cuqi/distribution/_beta.py
+++ b/cuqi/distribution/_beta.py
@@ -11,7 +11,7 @@ class Beta(Distribution):
 
     .. math::
 
-    f(x) = x^{(\alpha-1)}(1-x)^{(\beta-1)}\Gamma(\alpha+\beta) / (\Gamma(\alpha)\Gamma(\beta))
+        f(x) = x^{(\alpha-1)}(1-x)^{(\beta-1)}\Gamma(\alpha+\beta) / (\Gamma(\alpha)\Gamma(\beta))
 
     where :math:`\Gamma` is the Gamma function.
 

--- a/cuqi/distribution/_beta.py
+++ b/cuqi/distribution/_beta.py
@@ -18,8 +18,10 @@ class Beta(Distribution):
     Parameters
     ------------
     alpha: float or array_like
+           The shape parameter :math:`\\alpha` of the beta distribution.
 
     beta: float or array_like
+          The shape parameter :math:`\\beta` of the beta distribution.
     
     Example
     -------

--- a/cuqi/distribution/_beta.py
+++ b/cuqi/distribution/_beta.py
@@ -9,23 +9,17 @@ class Beta(Distribution):
     """
     Multivariate beta distribution of independent random variables x_i. Each is distributed according to the PDF function
 
-    f(x) = x^(alpha-1) * (1-x)^(beta-1) * Gamma(alpha+beta) / (Gamma(alpha)*Gamma(beta))
+    .. math::
 
-    where Gamma is the Gamma function.
+    f(x) = x^{(\alpha-1)}(1-x)^{(\beta-1)}\Gamma(\alpha+\beta) / (\Gamma(\alpha)\Gamma(\beta))
+
+    where :math:`\Gamma` is the Gamma function.
 
     Parameters
     ------------
     alpha: float or array_like
 
     beta: float or array_like
-
-    Methods
-    -----------
-    sample: generate one or more random samples
-    pdf: evaluate probability density function
-    logpdf: evaluate log probability density function
-    cdf: evaluate cumulative probability function
-    gradient: evaluate the gradient of the logpdf
     
     Example
     -------

--- a/cuqi/distribution/_custom.py
+++ b/cuqi/distribution/_custom.py
@@ -12,12 +12,6 @@ class UserDefinedDistribution(Distribution):
     gradient_func: Function evaluating the gradient of the logpdf. Callable.
     sample_func: Function drawing samples from distribution. Callable.
     
-    Methods
-    -----------
-    sample: generate one or more random samples
-    logpdf: evaluate log probability density function
-    gradient: evaluate gradient of logpdf
-    
     Example
     -----------
     .. code-block:: python

--- a/cuqi/distribution/_distribution.py
+++ b/cuqi/distribution/_distribution.py
@@ -28,37 +28,6 @@ class Distribution(Density, ABC):
     is_symmetric : bool, default None
         Indicator if distribution is symmetric.
 
-    Attributes
-    ----------
-    dim : int or None
-        Dimension of distribution.
-
-    name : str or None
-        Name of distribution.
-    
-    geometry : Geometry or None
-        Geometry of distribution.
-
-    is_cond : bool
-        Indicator if distribution is conditional.
-
-    Methods
-    -------
-    pdf():
-        Evaluate the probability density function.
-
-    logpdf():
-        Evaluate the log probability density function.
-
-    sample():
-        Generate one or more random samples.
-
-    get_conditioning_variables():
-        Return the conditioning variables of distribution.
-
-    get_mutable_variables():
-        Return the mutable variables (attributes and properties) of distribution.
-
     Notes
     -----
     A distribution can be conditional if one or more mutable variables are unspecified.

--- a/cuqi/distribution/_distribution.py
+++ b/cuqi/distribution/_distribution.py
@@ -208,6 +208,7 @@ class Distribution(Density, ABC):
             "enable_FD().")
 
     def sample(self,N=1,*args,**kwargs):
+        """ Sample from the distribution. """
 
         if self.is_cond:
             raise ValueError(f"Cannot sample from conditional distribution. Missing conditioning variables: {self.get_conditioning_variables()}")
@@ -232,6 +233,7 @@ class Distribution(Density, ABC):
         pass
 
     def pdf(self,x):
+        """ Evaluate the log probability density function of the distribution. """
         return np.exp(self.logpdf(x))
 
     def _condition(self, *args, **kwargs):

--- a/cuqi/distribution/_gamma.py
+++ b/cuqi/distribution/_gamma.py
@@ -9,7 +9,7 @@ class Gamma(Distribution):
 
     .. math::
     
-    f(x_i; \alpha, \beta) = \beta^\alpha x_i^{\alpha-1} \exp(-\beta x_i) / \Gamma(\alpha)
+        f(x_i; \alpha, \beta) = \beta^\alpha x_i^{\alpha-1} \exp(-\beta x_i) / \Gamma(\alpha)
 
     where shape :math:`\alpha` and rate :math:`\beta` are the parameters of the distribution, and Gamma is the Gamma function.
 
@@ -17,7 +17,7 @@ class Gamma(Distribution):
 
     .. math::
     
-    f(x_i; \alpha_i, \beta_i) = \beta_i^{\alpha_i} x_i^{\alpha_i-1} \exp(-\beta_i x_i) / \Gamma(\alpha_i)
+        f(x_i; \alpha_i, \beta_i) = \beta_i^{\alpha_i} x_i^{\alpha_i-1} \exp(-\beta_i x_i) / \Gamma(\alpha_i)
 
     Parameters
     ----------

--- a/cuqi/distribution/_gamma.py
+++ b/cuqi/distribution/_gamma.py
@@ -9,15 +9,15 @@ class Gamma(Distribution):
 
     .. math::
     
-        f(x_i; \alpha, \beta) = \beta^\alpha x_i^{\alpha-1} \exp(-\beta x_i) / \Gamma(\alpha)
+        f(x_i; \\alpha, \\beta) = \\beta^\\alpha x_i^{\\alpha-1} \\exp(-\\beta x_i) / \Gamma(\\alpha)
 
-    where shape :math:`\alpha` and rate :math:`\beta` are the parameters of the distribution, and Gamma is the Gamma function.
+    where shape :math:`\\alpha` and rate :math:`\\beta` are the parameters of the distribution, and :math:`\Gamma` is the Gamma function.
 
     In case shape and/or rate are arrays, the pdf looks like
 
     .. math::
     
-        f(x_i; \alpha_i, \beta_i) = \beta_i^{\alpha_i} x_i^{\alpha_i-1} \exp(-\beta_i x_i) / \Gamma(\alpha_i)
+        f(x_i; \\alpha_i, \\beta_i) = \\beta_i^{\\alpha_i} x_i^{\\alpha_i-1} \\exp(-\\beta_i x_i) / \Gamma(\\alpha_i)
 
     Parameters
     ----------

--- a/cuqi/distribution/_gamma.py
+++ b/cuqi/distribution/_gamma.py
@@ -6,14 +6,18 @@ from cuqi.utilities import force_ndarray
 class Gamma(Distribution):
     """
     Represents a multivariate Gamma distribution characterized by shape and rate parameters of independent random variables x_i. Each is distributed according to the PDF function
-    
-    f(x_i; shape, rate) = rate^shape * x_i^(shape-1) * exp(-rate * x_i) / Gamma(shape)
 
-    where `shape` and `rate` are the parameters of the distribution, and Gamma is the Gamma function.
+    .. math::
+    
+    f(x_i; \alpha, \beta) = \beta^\alpha x_i^{\alpha-1} \exp(-\beta x_i) / \Gamma(\alpha)
+
+    where shape :math:`\alpha` and rate :math:`\beta` are the parameters of the distribution, and Gamma is the Gamma function.
 
     In case shape and/or rate are arrays, the pdf looks like
 
-    f(x_i; shape_i, rate_i) = rate_i^shape_i * x_i^(shape_i-1) * exp(-rate_i * x_i) / Gamma(shape_i)
+    .. math::
+    
+    f(x_i; \alpha_i, \beta_i) = \beta_i^{\alpha_i} x_i^{\alpha_i-1} \exp(-\beta_i x_i) / \Gamma(\alpha_i)
 
     Parameters
     ----------

--- a/cuqi/distribution/_gaussian.py
+++ b/cuqi/distribution/_gaussian.py
@@ -730,18 +730,6 @@ class JointGaussianSqrtPrec(Distribution):
     ------------
     means: List of means for each Gaussian distribution.
     sqrtprecs: List of sqrt precision matricies for each Gaussian distribution.
-
-    Attributes
-    ------------
-    sqrtprec: Returns the sqrt precision matrix of the joined gaussian in stacked form.
-    sqrtprecTimesMean: Returns the sqrt precision matrix times the mean of the distribution.
-    
-    Methods
-    -----------
-    sample: generate one or more random samples (NotImplemented)
-    pdf: evaluate probability density function (NotImplemented)
-    logpdf: evaluate log probability density function (NotImplemented)
-    cdf: evaluate cumulative probability function (NotImplemented)
     """    
     def __init__(self,means=None,sqrtprecs=None,is_symmetric=True,**kwargs):
 
@@ -783,6 +771,7 @@ class JointGaussianSqrtPrec(Distribution):
 
     @property
     def sqrtprec(self):
+        """ Returns the sqrt precision matrix of the joined gaussian in stacked form. """
         if spa.issparse(self._sqrtprecs[0]):
             return spa.vstack((self._sqrtprecs))
         else:
@@ -790,6 +779,7 @@ class JointGaussianSqrtPrec(Distribution):
 
     @property
     def sqrtprecTimesMean(self):
+        """ Returns the sqrt precision matrix times the mean of the distribution."""
         result = []
         for i in range(len(self._means)):
             result.append((self._sqrtprecs[i]@self._means[i]).flatten())

--- a/cuqi/distribution/_inverse_gamma.py
+++ b/cuqi/distribution/_inverse_gamma.py
@@ -8,9 +8,11 @@ class InverseGamma(Distribution):
     """
     Multivariate inverse gamma distribution of independent random variables x_i. Each is distributed according to the PDF function
 
-    f(x) = (x-location)^(-shape-1) * exp(-scale/(x-location)) / (scale^(-shape)*Gamma(shape))
+    .. math::
 
-    where shape, location and scale are the shape, location and scale of x_i, respectively. And Gamma is the Gamma function.
+        f(x) = (x-\\beta)^{(-\\alpha-1)} * \exp(-\\gamma/(x-\\beta)) / (\\gamma^{(-\\alpha)}*\Gamma(\\alpha))
+
+    where shape :math:`\\alpha`, location :math:`\\beta` and scale :math:`\\gamma` are the shape, location and scale of x_i, respectively. And Gamma is the Gamma function.
 
     Parameters
     ------------
@@ -23,14 +25,6 @@ class InverseGamma(Distribution):
     scale: float or array_like
         The scale of the inverse gamma distribution (non-negative)
 
-    
-    Methods
-    -----------
-    sample: generate one or more random samples
-    pdf: evaluate probability density function
-    logpdf: evaluate log probability density function
-    cdf: evaluate cumulative probability function
-    
     Example
     -------
     .. code-block:: python

--- a/cuqi/distribution/_lognormal.py
+++ b/cuqi/distribution/_lognormal.py
@@ -16,13 +16,6 @@ class Lognormal(Distribution):
     cov: np.ndarray
         Covariance matrix of the normal distribution used to define the lognormal distribution 
     
-    Methods
-    -----------
-    sample: generate one or more random samples
-    pdf: evaluate probability density function
-    logpdf: evaluate log probability density function
-    cdf: evaluate cumulative probability function
-    
     Example
     -------
     .. code-block:: python

--- a/cuqi/distribution/_modifiedhalfnormal.py
+++ b/cuqi/distribution/_modifiedhalfnormal.py
@@ -25,13 +25,13 @@ class ModifiedHalfNormal(Distribution):
     Parameters
     ----------
     alpha : float
-        The polynomial exponent parameter of the MHN distribution. Must be positive.
+        The polynomial exponent parameter :math:`\\alpha` of the MHN distribution. Must be positive.
 
     beta : float
-        The quadratic exponential parameter of the MHN distribution. Must be positive.
+        The quadratic exponential parameter :math:`\\beta` of the MHN distribution. Must be positive.
 
     gamma : float
-        The linear exponential parameter of the MHN distribution.
+        The linear exponential parameter :math:`\\gamma` of the MHN distribution.
 
     """
     def __init__(self, alpha=None, beta=None, gamma=None, is_symmetric=False, **kwargs):

--- a/cuqi/distribution/_modifiedhalfnormal.py
+++ b/cuqi/distribution/_modifiedhalfnormal.py
@@ -7,14 +7,17 @@ from cuqi.utilities import force_ndarray
 class ModifiedHalfNormal(Distribution):
     """
     Represents a modified half-normal (MHN) distribution, a three-parameter family of distributions generalizing the Gamma distribution.
-    The distribution is continuous with pdf 
-    f(x; alpha, beta, gamma) propto x^(alpha-1) * exp(-beta * x^2 + gamma * x)
+    The distribution is continuous with pdf
+
+    .. math::
+    
+        f(x; \\alpha, \\beta, \\gamma) \propto x^{(\\alpha-1)} * \exp(-\\beta * x^2 + \\gamma * x)
 
     The MHN generalizes the half-normal distribution, because
-    f(x; 1, beta, 0) propto exp(-beta * x^2)
+    :math:`f(x; 1, \\beta, 0) \propto \exp(-\\beta * x^2)`
 
     The MHN generalizes the gamma distribution because
-    f(x; alpha, 0, -gamma) propto x^(alpha-1) * exp(- gamma * x)
+    :math:`f(x; \\alpha, 0, -\\gamma) \propto x^{(\\alpha-1)} * \exp(- \\gamma * x)`
 
     Reference:
     [1] Sun, et al. "The Modified-Half-Normal distribution: Properties and an efficient sampling scheme." Communications in Statistics-Theory and Methods

--- a/cuqi/distribution/_normal.py
+++ b/cuqi/distribution/_normal.py
@@ -12,13 +12,6 @@ class Normal(Distribution):
     mean: mean of distribution
     std: standard deviation
     
-    Methods
-    -----------
-    sample: generate one or more random samples
-    pdf: evaluate probability density function
-    logpdf: evaluate log probability density function
-    cdf: evaluate cumulative probability function
-    
     Example
     -----------
     .. code-block:: python

--- a/cuqi/samples/_samples.py
+++ b/cuqi/samples/_samples.py
@@ -565,7 +565,7 @@ class Samples(object):
 
 
     def diagnostics(self):
-        """ Conducts diagnostics on the chain. """
+        """ Conducts diagnostics on the chain (Geweke test). """
         # Geweke test
         Geweke(self.samples.T)
 

--- a/cuqi/samples/_samples.py
+++ b/cuqi/samples/_samples.py
@@ -36,24 +36,6 @@ class Samples(object):
     geometry : cuqi.geometry.Geometry, default None
         Contains the geometry related of the samples
 
-    Attributes
-    ----------
-    shape : tuple
-        Returns the shape of samples.
-
-    Ns : int
-        Returns the number of samples
-
-    Methods
-    ----------
-    :meth:`plot`: Plots one or more samples.
-    :meth:`plot_ci`: Plots a credibility interval for the samples.
-    :meth:`plot_mean`: Plots the mean of the samples.
-    :meth:`plot_std`: Plots the std of the samples.
-    :meth:`plot_chain`: Plots all samples of one or more variables (MCMC chain).
-    :meth:`hist_chain`: Plots histogram of all samples of a single variable (MCMC chain).
-    :meth:`burnthin`: Removes burn-in and thins samples.
-    :meth:`diagnostics`: Conducts diagnostics on the chain.
     """
     def __init__(self, samples, geometry=None, is_par=True, is_vec=True):
         self.geometry = geometry
@@ -83,6 +65,7 @@ class Samples(object):
 
     @property
     def shape(self):
+        """Returns the shape of samples."""
         return self.samples.shape
 
     @property
@@ -408,6 +391,7 @@ class Samples(object):
         return ax
 
     def plot(self,sample_indices=None,*args,**kwargs):
+        """ Plots one or more samples. """
         Ns = self.Ns
         Np = 5 # Number of samples to plot if Ns > 5
 
@@ -447,6 +431,7 @@ class Samples(object):
         return lines
     
     def hist_chain(self,variable_indices,*args,**kwargs):
+        """ Plots histogram of all samples of a single variable (MCMC chain). """
 
         self._raise_error_if_not_vec(self.hist_chain.__name__)
 
@@ -580,6 +565,7 @@ class Samples(object):
 
 
     def diagnostics(self):
+        """ Conducts diagnostics on the chain. """
         # Geweke test
         Geweke(self.samples.T)
 

--- a/cuqi/samples/_samples.py
+++ b/cuqi/samples/_samples.py
@@ -431,7 +431,7 @@ class Samples(object):
         return lines
     
     def hist_chain(self,variable_indices,*args,**kwargs):
-        """ Plots histogram of all samples of a single variable (MCMC chain). """
+        """ Plots samples histogram of variables with indices specified in variable_indices. """
 
         self._raise_error_if_not_vec(self.hist_chain.__name__)
 

--- a/cuqi/solver/_solver.py
+++ b/cuqi/solver/_solver.py
@@ -174,9 +174,12 @@ class LS(object):
     """Wrapper for :meth:`scipy.optimize.least_squares`.
 
     Solve nonlinear least-squares problems with bounds:
+
+    .. math::
     
-    minimize F(x) = 0.5 * sum(rho(f_i(x)**2), i = 0, ..., m-1)
-    subject to lb <= x <= ub
+        \min F(x) = 0.5 * \sum(\\rho(f_i(x)^2), i = 0, ..., m-1)
+
+    subject to :math:`lb <= x <= ub`.
     
     Parameters
     ----------

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -19,6 +19,9 @@ Some useful auxiliary helper modules:
    - :doc:`cuqi.samples <_autosummary/cuqi.samples>` contains tools for storing and manipulating MCMC samples.
    - :doc:`cuqi.solver <_autosummary/cuqi.solver>` contains tools point estimation of posteriors.
 
+Experimental modules:
+   - :doc:`cuqi.experimental <_autosummary/cuqi.experimental>` contains experimental modules that are not yet stable.
+
 Full API overview
    A complete auto generated overview of the API can be found below (or by navigating using the sidebar).
 


### PR DESCRIPTION
fix #470 

Major changes I made:
- removed the manually inserted sections of `Attributes` and `Methods` from the docstring of class. Instead, we move respective docstrings to the definition of relevant properties and methods. Then we rely on sphinx to automatically capture the docstring.
- updated math equations, mainly in distribution and its subclasses, so the equations are rendered correctly.
- added `experiment.mcmc` to the overall API page, which will appear at the bottom of https://cuqi-dtu.github.io/CUQIpy/api/index.html