### PR TITLE
move tqdm from requirement-dev to requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,3 @@ sphinx-panels
 sphinx-copybutton
 sphinx-gallery
 versioneer==0.26
-tqdm # For experimental mcmc module

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ matplotlib
 numpy>=1.17.0
 scipy<1.13
 arviz
+tqdm


### PR DESCRIPTION
fixed #506 

With this _tiny_ PR, samplers in `cuqi.experimental.mcmc` will give cleaner screen output during sampling, particularly for jupyter notebooks.