### PR TITLE
Add gradient to uniform distribution

### DIFF
--- a/cuqi/distribution/_uniform.py
+++ b/cuqi/distribution/_uniform.py
@@ -46,12 +46,8 @@ class Uniform(Distribution):
         Computes the gradient of logpdf at the given values of x.
         """
         # x accepts scalar, list, tuple, or ndarray
-        if np.any(x < self.low) or np.any(x > self.high):
-            # If outside always return NaN
-            return_val = np.NaN*np.ones_like(x)
-        else:
-            tol = -1e16
-            return tol*np.ones_like(x)
+        tol = -1e16
+        return tol*np.ones_like(x)
 
     def _sample(self,N=1, rng=None):
 

--- a/cuqi/distribution/_uniform.py
+++ b/cuqi/distribution/_uniform.py
@@ -21,6 +21,9 @@ class Uniform(Distribution):
         self.high = high      
 
     def logpdf(self, x):
+        """
+        Evaluate the logarithm of the PDF at the given values of x.
+        """
         # First check whether x is outside bounds.
         # It is outside if any coordinate is outside the interval.
         if np.any(x < self.low) or np.any(x > self.high):
@@ -37,6 +40,13 @@ class Uniform(Distribution):
                 v = diff
             return_val = np.log(1.0/v)
         return return_val
+
+    def gradient(self, x):
+        """
+        Computes the gradient of logpdf at the given values of x.
+        """
+        # x accepts scalar, list, tuple, or ndarray
+        return np.zeros_like(x)
 
     def _sample(self,N=1, rng=None):
 

--- a/cuqi/distribution/_uniform.py
+++ b/cuqi/distribution/_uniform.py
@@ -45,9 +45,10 @@ class Uniform(Distribution):
         """
         Computes the gradient of logpdf at the given values of x.
         """
-        # x accepts scalar, list, tuple, or ndarray
-        tol = -1e16
-        return tol*np.ones_like(x)
+        if np.any(x < self.low) or np.any(x > self.high):
+            return np.NaN*np.ones_like(x)
+        else:
+            return np.zeros_like(x)
 
     def _sample(self,N=1, rng=None):
 

--- a/cuqi/distribution/_uniform.py
+++ b/cuqi/distribution/_uniform.py
@@ -46,7 +46,8 @@ class Uniform(Distribution):
         Computes the gradient of logpdf at the given values of x.
         """
         # x accepts scalar, list, tuple, or ndarray
-        return np.zeros_like(x)
+        tol = -1e16
+        return tol*np.ones_like(x)
 
     def _sample(self,N=1, rng=None):
 

--- a/cuqi/distribution/_uniform.py
+++ b/cuqi/distribution/_uniform.py
@@ -46,8 +46,12 @@ class Uniform(Distribution):
         Computes the gradient of logpdf at the given values of x.
         """
         # x accepts scalar, list, tuple, or ndarray
-        tol = -1e16
-        return tol*np.ones_like(x)
+        if np.any(x < self.low) or np.any(x > self.high):
+            # If outside always return NaN
+            return_val = np.NaN*np.ones_like(x)
+        else:
+            tol = -1e16
+            return tol*np.ones_like(x)
 
     def _sample(self,N=1, rng=None):
 

--- a/tests/test_distributions_shape.py
+++ b/tests/test_distributions_shape.py
@@ -95,7 +95,8 @@ def test_multivariate_scalar_vars_gradient(dist):
     try:
         assert np.allclose(
             dist_from_vec.gradient(val),
-            dist_from_dim.gradient(val)
+            dist_from_dim.gradient(val),
+            equal_nan=True
         )
     except NotImplementedError:
         pass  # Pass the test if NotImplementedError is raised


### PR DESCRIPTION
fixed #495 .

- I have tested the implementation with MALA, ULA and NUTS from `cuqi.experimental.mcmc` for two demos (see below for MWE code);
- `sample` goes well for all these three samplers
- `warmup` from NUTS is always stuck at some point and I created a separate issue to keep track of it #529 

## Demo 1: draw samples from Uniform(0, 1) with MALA, ULA and NUTS

```python
import cuqi
import matplotlib.pyplot as plt
import numpy as np

uniform = cuqi.distribution.Uniform(np.array([0.0]), np.array([1.0]))
# sampler = cuqi.experimental.mcmc.MALA(uniform, initial_point=np.array([0.1]))
# sampler = cuqi.experimental.mcmc.ULA(uniform, initial_point=np.array([0.1]))
sampler = cuqi.experimental.mcmc.NUTS(uniform, initial_point=np.array([0.1]))
sampler.sample(10000)
samples = sampler.get_samples()
samples.plot_trace()
```

![image](https://github.com/user-attachments/assets/048a1bc2-66a3-4680-9b38-ff78686a9a62)

## Demo 2: solve ["Simplest" BIP](https://cuqi-dtu.github.io/CUQI-Book/chapter01/intro_example_short.html) with MALA, ULA and NUTS

```python
import numpy as np
import matplotlib.pyplot as plt
import cuqi
from cuqi.utilities import plot_2D_density
np.random.seed(10)

# the forward model
A_matrix = np.array([[1.0, 1.0]])
A = cuqi.model.LinearModel(A_matrix)

# the prior
# x = Gaussian(np.zeros(2), 2.5)
x = cuqi.distribution.Uniform(np.array([-1.0, -1.0]), np.array([3.0, 3.0]))
print(x)

# the data distribution
b = cuqi.distribution.Gaussian(A@x, 0.1)

# the observed data
particular_x = np.array([1.5, 1.5])
b_given_particular_x = b(x=particular_x)
b_obs = b_given_particular_x.sample()
print(b_obs)

# the posterior
joint = cuqi.distribution.JointDistribution(x, b)
post = joint(b=b_obs)

# sampling with MALA, ULA and NUTS
# sampler = cuqi.experimental.mcmc.MALA(post, initial_point=np.array([2.5, 2.5]), scale=0.12)
# sampler = cuqi.experimental.mcmc.ULA(post, initial_point=np.array([2.5, 2.5]), scale=0.12)
sampler = cuqi.experimental.mcmc.NUTS(post, initial_point=np.array([2.5, 2.5]))

# sampler.warmup(1000)
sampler.sample(1000)
samples = sampler.get_samples()
samples.plot_trace()

# what b looks like with the drawn samples?
b_with_samples = cuqi.samples.Samples(samples.samples[:1,:] + samples.samples[1:,:])
plt.figure()
b_with_samples.plot_trace()

# plot exact posterior distribution and samples
# the posterior PDF
plt.figure()
plot_2D_density(post, -5, 5, -5, 5)
plt.title("Exact Posterior")

# samples
plt.figure()
samples.plot_pair()
plt.xlim(-5, 5)
plt.ylim(-5, 5)
plt.gca().set_aspect('equal')
plt.title("Posterior Samples")

```
![image](https://github.com/user-attachments/assets/d83f21a4-928a-4b1c-945f-fb052780233f)
The following plot shows what x1+x2 looks like with the drawn samples
![image](https://github.com/user-attachments/assets/1aa8358e-8571-4ff1-b924-6fc17ee48728)
![image](https://github.com/user-attachments/assets/0397d734-138e-4fb2-91f3-9669ca44d813)
![image](https://github.com/user-attachments/assets/0ea52abf-bd55-491e-9100-c93d4af7ddb4)




