### PR TITLE
Display acc rate on progress bar

### DIFF
--- a/cuqi/experimental/mcmc/_hmc.py
+++ b/cuqi/experimental/mcmc/_hmc.py
@@ -258,7 +258,7 @@ class NUTS(Sampler):
                 self.current_point = point_prime
                 self.current_target_logd = logd_prime
                 self.current_target_grad = np.copy(grad_prime)
-                acc = acc or 1
+                acc = 1
 
 
             # update number of particles, tree level, and stopping criterion

--- a/cuqi/experimental/mcmc/_sampler.py
+++ b/cuqi/experimental/mcmc/_sampler.py
@@ -231,9 +231,7 @@ class Sampler(ABC):
             self._samples.append(self.current_point)
 
             # display acc rate at progress bar
-            # workaround for None values in acc of NUTS
-            acc_filtered = list(filter(lambda x: x is not None, self._acc))
-            pbar.set_postfix_str(f"acc rate: {np.mean(acc_filtered):.2%}")
+            pbar.set_postfix_str(f"acc rate: {np.mean(self._acc):.2%}")
 
             # Add sample to batch
             if batch_size > 0:
@@ -281,9 +279,7 @@ class Sampler(ABC):
             self._samples.append(self.current_point)
 
             # display acc rate at progress bar
-            # workaround for None values in acc of NUTS
-            acc_filtered = list(filter(lambda x: x is not None, self._acc))
-            pbar.set_postfix_str(f"acc rate: {np.mean(acc_filtered):.2%}")
+            pbar.set_postfix_str(f"acc rate: {np.mean(self._acc):.2%}")
 
             # Call callback function if specified
             self._call_callback(self.current_point, len(self._samples)-1)

--- a/cuqi/experimental/mcmc/_sampler.py
+++ b/cuqi/experimental/mcmc/_sampler.py
@@ -220,7 +220,8 @@ class Sampler(ABC):
         if hasattr(self, "_pre_sample"): self._pre_sample()
 
         # Draw samples
-        for _ in tqdm( range(Ns), "Sample: "):
+        pbar = tqdm(range(Ns), "Sample: ")
+        for _ in pbar:
             
             # Perform one step of the sampler
             acc = self.step()
@@ -228,6 +229,11 @@ class Sampler(ABC):
             # Store samples
             self._acc.append(acc)
             self._samples.append(self.current_point)
+
+            # display acc rate at progress bar
+            # workaround for None values in acc of NUTS
+            acc_filtered = list(filter(lambda x: x is not None, self._acc))
+            pbar.set_postfix_str(f"acc rate: {np.mean(acc_filtered):.2%}")
 
             # Add sample to batch
             if batch_size > 0:
@@ -260,7 +266,8 @@ class Sampler(ABC):
         if hasattr(self, "_pre_warmup"): self._pre_warmup()
 
         # Draw warmup samples with tuning
-        for idx in tqdm(range(Nb), "Warmup: "):
+        pbar = tqdm(range(Nb), "Warmup: ")
+        for idx in pbar:
 
             # Perform one step of the sampler
             acc = self.step()
@@ -272,6 +279,11 @@ class Sampler(ABC):
             # Store samples
             self._acc.append(acc)
             self._samples.append(self.current_point)
+
+            # display acc rate at progress bar
+            # workaround for None values in acc of NUTS
+            acc_filtered = list(filter(lambda x: x is not None, self._acc))
+            pbar.set_postfix_str(f"acc rate: {np.mean(acc_filtered):.2%}")
 
             # Call callback function if specified
             self._call_callback(self.current_point, len(self._samples)-1)

--- a/cuqi/experimental/mcmc/_sampler.py
+++ b/cuqi/experimental/mcmc/_sampler.py
@@ -221,7 +221,7 @@ class Sampler(ABC):
 
         # Draw samples
         pbar = tqdm(range(Ns), "Sample: ")
-        for _ in pbar:
+        for idx in pbar:
             
             # Perform one step of the sampler
             acc = self.step()
@@ -231,7 +231,7 @@ class Sampler(ABC):
             self._samples.append(self.current_point)
 
             # display acc rate at progress bar
-            pbar.set_postfix_str(f"acc rate: {np.mean(self._acc):.2%}")
+            pbar.set_postfix_str(f"acc rate: {np.mean(self._acc[-1-idx:]):.2%}")
 
             # Add sample to batch
             if batch_size > 0:
@@ -279,7 +279,7 @@ class Sampler(ABC):
             self._samples.append(self.current_point)
 
             # display acc rate at progress bar
-            pbar.set_postfix_str(f"acc rate: {np.mean(self._acc):.2%}")
+            pbar.set_postfix_str(f"acc rate: {np.mean(self._acc[-1-idx:]):.2%}")
 
             # Call callback function if specified
             self._call_callback(self.current_point, len(self._samples)-1)


### PR DESCRIPTION
fixed #374 .

(edit be @amal-ghamdi , also closes #532 )

## Discription
So far, I only added `acc rate` information to the right end of the progress bar. 

With the following MWE,
```python
import cuqi
import matplotlib.pyplot as plt
import numpy as np

uniform = cuqi.distribution.Uniform(np.array([0.0]), np.array([1.0]))
sampler = cuqi.experimental.mcmc.MALA(uniform, initial_point=np.array([0.1]))
sampler.warmup(10000)
sampler.sample(10000)
samples = sampler.get_samples()
samples.plot_trace()
```
the progress bar will look like:
```bash
Warmup: 100%|██████████| 10000/10000 [00:08<00:00, 1144.12it/s, acc rate: 35.98%]
Sample: 100%|██████████| 10000/10000 [00:13<00:00, 722.34it/s, acc rate: 36.17%]
```
Note the `acc rate: XX.XX%` at the end.

## Questions
- Do we need/want to add any other information?
- Do we want to display the acc rate of
  - [ ] the (up-to-date) whole chain (which might be samples from multiple sample/warmups) or
  - [x] the samples from the current sample/warmup?

## Note
It seems NUTS stores some extra `None` in `_acc` and I have created an issue for it: #532 : addressed by @amal-ghamdi  