### PR TITLE
Add (iid) truncated normal and also add grad to normal

### DIFF
--- a/cuqi/distribution/__init__.py
+++ b/cuqi/distribution/__init__.py
@@ -12,6 +12,7 @@ from ._laplace import Laplace
 from ._smoothed_laplace import SmoothedLaplace
 from ._lognormal import Lognormal
 from ._normal import Normal
+from ._truncated_normal import TruncatedNormal
 from ._posterior import Posterior
 from ._uniform import Uniform
 from ._custom import UserDefinedDistribution, DistributionGallery

--- a/cuqi/distribution/_normal.py
+++ b/cuqi/distribution/_normal.py
@@ -65,8 +65,7 @@ class Normal(Distribution):
         elif hasattr(self.mean, "gradient"): # for likelihood
             model = self.mean
             dev = val - model.forward(*args, **kwargs)
-            if isinstance(dev, numbers.Number):
-                dev = np.array([dev])
+            print(dev)
             return model.gradient(1.0/(np.array(self.std)) @ dev, *args, **kwargs)
         else:
             raise NotImplementedError("Gradient not implemented for distribution {} with location {}".format(self,self.mean))

--- a/cuqi/distribution/_normal.py
+++ b/cuqi/distribution/_normal.py
@@ -36,6 +36,9 @@ class Normal(Distribution):
     def cdf(self, x):
         return np.prod(0.5*(1 + erf((x-self.mean)/(self.std*np.sqrt(2)))))
 
+    def gradient(self, x):
+        return -(x-self.mean)/(self.std**2)
+
     def _sample(self,N=1, rng=None):
 
         """

--- a/cuqi/distribution/_normal.py
+++ b/cuqi/distribution/_normal.py
@@ -1,6 +1,7 @@
 import numpy as np
 from scipy.special import erf
 from cuqi.geometry import _get_identity_geometries
+from cuqi.utilities import force_ndarray
 from cuqi.distribution import Distribution
 
 class Normal(Distribution):
@@ -27,6 +28,24 @@ class Normal(Distribution):
         # Init specific to this distribution
         self.mean = mean
         self.std = std
+
+    @property
+    def mean(self):
+        """ Mean of the distribution """
+        return self._mean
+
+    @mean.setter
+    def mean(self, value):
+        self._mean = force_ndarray(value, flatten=True)
+
+    @property
+    def std(self):
+        """ Std of the distribution """
+        return self._std
+
+    @mean.setter
+    def std(self, value):
+        self._std = force_ndarray(value, flatten=True)
 
     def pdf(self, x):
         return np.prod(1/(self.std*np.sqrt(2*np.pi))*np.exp(-0.5*((x-self.mean)/self.std)**2))

--- a/cuqi/distribution/_normal.py
+++ b/cuqi/distribution/_normal.py
@@ -1,4 +1,5 @@
 import numpy as np
+import numbers
 from scipy.special import erf
 from cuqi.geometry import _get_identity_geometries
 from cuqi.utilities import force_ndarray
@@ -61,9 +62,14 @@ class Normal(Distribution):
             raise NotImplementedError("Gradient not implemented for distribution {} with geometry {}".format(self,self.geometry))
         if not callable(self.mean):
             return -(val-self.mean)/(self.std**2)
+        elif hasattr(self.mean, "gradient"): # for likelihood
+            model = self.mean
+            dev = val - model.forward(*args, **kwargs)
+            if isinstance(dev, numbers.Number):
+                dev = np.array([dev])
+            return model.gradient(1.0/(np.array(self.std)) @ dev, *args, **kwargs)
         else:
             raise NotImplementedError("Gradient not implemented for distribution {} with location {}".format(self,self.mean))
-
 
     def _sample(self,N=1, rng=None):
 

--- a/cuqi/distribution/_normal.py
+++ b/cuqi/distribution/_normal.py
@@ -43,7 +43,7 @@ class Normal(Distribution):
         """ Std of the distribution """
         return self._std
 
-    @mean.setter
+    @std.setter
     def std(self, value):
         self._std = force_ndarray(value, flatten=True)
 

--- a/cuqi/distribution/_normal.py
+++ b/cuqi/distribution/_normal.py
@@ -1,4 +1,5 @@
 import numpy as np
+from scipy.special import erf
 from cuqi.geometry import _get_identity_geometries
 from cuqi.distribution import Distribution
 
@@ -43,6 +44,7 @@ class Normal(Distribution):
             return -(val-self.mean)/(self.std**2)
         else:
             raise NotImplementedError("Gradient not implemented for distribution {} with location {}".format(self,self.mean))
+
 
     def _sample(self,N=1, rng=None):
 

--- a/cuqi/distribution/_normal.py
+++ b/cuqi/distribution/_normal.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.special import erf
+from cuqi.geometry import _get_identity_geometries
 from cuqi.distribution import Distribution
 
 class Normal(Distribution):
@@ -36,8 +36,13 @@ class Normal(Distribution):
     def cdf(self, x):
         return np.prod(0.5*(1 + erf((x-self.mean)/(self.std*np.sqrt(2)))))
 
-    def gradient(self, x):
-        return -(x-self.mean)/(self.std**2)
+    def _gradient(self, val, *args, **kwargs):
+        if not type(self.geometry) in _get_identity_geometries():
+            raise NotImplementedError("Gradient not implemented for distribution {} with geometry {}".format(self,self.geometry))
+        if not callable(self.mean):
+            return -(val-self.mean)/(self.std**2)
+        else:
+            raise NotImplementedError("Gradient not implemented for distribution {} with location {}".format(self,self.mean))
 
     def _sample(self,N=1, rng=None):
 

--- a/cuqi/distribution/_truncated_normal.py
+++ b/cuqi/distribution/_truncated_normal.py
@@ -78,6 +78,7 @@ class TruncatedNormal(Distribution):
         """
         Generates random samples from the distribution.
         """
+        # FIXME: this implementation does not honor the rng
         max_iter = 1e9 # maximum number of trials to avoid infinite loop
         samples = []
         for i in range(int(max_iter)):

--- a/cuqi/distribution/_truncated_normal.py
+++ b/cuqi/distribution/_truncated_normal.py
@@ -72,4 +72,15 @@ class TruncatedNormal(Distribution):
         """
         Generates random samples from the distribution.
         """
-        raise NotImplementedError(f"sample is not implemented for {self.__class__.__name__}.")
+        max_iter = 1e9 # maximum number of trials to avoid infinite loop
+        samples = []
+        for i in range(int(max_iter)):
+            if len(samples) == N:
+                break
+            sample = self._normal.sample()
+            if np.all(sample >= self.low) and np.all(sample <= self.high):
+                samples.append(sample)
+        # raise a error if the number of iterations exceeds max_iter
+        if i == max_iter-1:
+            raise RuntimeError("Failed to generate {} samples within {} iterations".format(N, max_iter))
+        return np.array(samples).T.reshape(-1,N)

--- a/cuqi/distribution/_truncated_normal.py
+++ b/cuqi/distribution/_truncated_normal.py
@@ -1,6 +1,7 @@
 import numpy as np
 from scipy.special import erf
 from cuqi.distribution import Distribution
+from cuqi.distribution import Normal
 
 class TruncatedNormal(Distribution):
     """
@@ -30,20 +31,23 @@ class TruncatedNormal(Distribution):
         self.low = low
         self.high = high
 
+        # Init underlying normal distribution
+        self._normal = Normal(self.mean, self.std)
+
     def logpdf(self, x):
         # the unnormalized logpdf
         # check if x falls in the range between np.array a and b
         if np.any(x < self.low) or np.any(x > self.high):
             return -np.Inf
         else:
-             return np.sum(-np.log(self.std*np.sqrt(2*np.pi))-0.5*((x-self.mean)/self.std)**2)
+             return self._normal.logpdf(x)
 
     def gradient(self, x):
         # check if x falls in the range between np.array a and b
         if np.any(x < self.low) or np.any(x > self.high):
             return np.NaN*np.ones_like(x)
         else:
-            return -(x-self.mean)/(self.std**2)
+            return self._normal.gradient(x)
 
     def _sample(self,N=1, rng=None):
         """

--- a/cuqi/distribution/_truncated_normal.py
+++ b/cuqi/distribution/_truncated_normal.py
@@ -11,32 +11,36 @@ class TruncatedNormal(Distribution):
     
     Parameters
     ------------
-    mean: mean of distribution
-    std: standard deviation
-    a: lower bound of the distribution
-    b: upper bound of the distribution
+    mean : float or array_like of floats
+        mean of distribution
+    std : float or array_like of floats
+        standard deviation
+    a : float or array_like of floats
+        lower bound of the distribution
+    b : float or array_like of floats
+        upper bound of the distribution
     """
-    def __init__(self, mean=None, std=None, a=-np.Inf, b=np.Inf, is_symmetric=False, **kwargs):
+    def __init__(self, mean=None, std=None, low=-np.Inf, high=np.Inf, is_symmetric=False, **kwargs):
         # Init from abstract distribution class
         super().__init__(is_symmetric=is_symmetric, **kwargs)  
 
         # Init specific to this distribution
         self.mean = mean
         self.std = std
-        self.a = a
-        self.b = b
+        self.low = low
+        self.high = high
 
     def logpdf(self, x):
         # the unnormalized logpdf
         # check if x falls in the range between np.array a and b
-        if np.any(x < self.a) or np.any(x > self.b):
+        if np.any(x < self.low) or np.any(x > self.high):
             return -np.Inf
         else:
              return np.sum(-np.log(self.std*np.sqrt(2*np.pi))-0.5*((x-self.mean)/self.std)**2)
 
     def gradient(self, x):
         # check if x falls in the range between np.array a and b
-        if np.any(x < self.a) or np.any(x > self.b):
+        if np.any(x < self.low) or np.any(x > self.high):
             return np.NaN*np.ones_like(x)
         else:
             return -(x-self.mean)/(self.std**2)

--- a/cuqi/distribution/_truncated_normal.py
+++ b/cuqi/distribution/_truncated_normal.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy.special import erf
+from cuqi.utilities import force_ndarray
 from cuqi.distribution import Distribution
 from cuqi.distribution import Normal
 
@@ -48,6 +49,26 @@ class TruncatedNormal(Distribution):
 
         # Init underlying normal distribution
         self._normal = Normal(self.mean, self.std, is_symmetric=is_symmetric, **kwargs)
+
+    @property
+    def mean(self):
+        """ Mean of the distribution """
+        return self._mean
+
+    @mean.setter
+    def mean(self, value):
+        self._mean = force_ndarray(value, flatten=True)
+        self._normal.mean = self._mean
+
+    @property
+    def std(self):
+        """ Std of the distribution """
+        return self._std
+
+    @std.setter
+    def std(self, value):
+        self._std = force_ndarray(value, flatten=True)
+        self._normal.std = self._std
 
     def logpdf(self, x):
         """

--- a/cuqi/distribution/_truncated_normal.py
+++ b/cuqi/distribution/_truncated_normal.py
@@ -54,6 +54,9 @@ class TruncatedNormal(Distribution):
         self._normal = Normal(self.mean, self.std)
 
     def logpdf(self, x):
+        """
+        Computes the unnormalized logpdf at the given values of x.
+        """
         # the unnormalized logpdf
         # check if x falls in the range between np.array a and b
         if np.any(x < self.low) or np.any(x > self.high):
@@ -62,6 +65,9 @@ class TruncatedNormal(Distribution):
              return self._normal.logpdf(x)
 
     def gradient(self, x):
+        """
+        Computes the gradient of the unnormalized logpdf at the given values of x.
+        """
         # check if x falls in the range between np.array a and b
         if np.any(x < self.low) or np.any(x > self.high):
             return np.NaN*np.ones_like(x)

--- a/cuqi/distribution/_truncated_normal.py
+++ b/cuqi/distribution/_truncated_normal.py
@@ -74,7 +74,6 @@ class TruncatedNormal(Distribution):
         """
         Generates random samples from the distribution.
         """
-        # FIXME: this implementation does not honor the rng
         max_iter = 1e9 # maximum number of trials to avoid infinite loop
         samples = []
         for i in range(int(max_iter)):

--- a/cuqi/distribution/_truncated_normal.py
+++ b/cuqi/distribution/_truncated_normal.py
@@ -72,6 +72,24 @@ class TruncatedNormal(Distribution):
         if hasattr(self, '_normal'):
             self._normal.std = self._std
 
+    @property
+    def low(self):
+        """ Lower bound of the distribution """
+        return self._low
+
+    @low.setter
+    def low(self, value):
+        self._low = force_ndarray(value, flatten=True)
+
+    @property
+    def high(self):
+        """ Higher bound of the distribution """
+        return self._high
+
+    @high.setter
+    def high(self, value):
+        self._high = force_ndarray(value, flatten=True)
+
     def logpdf(self, x):
         """
         Computes the unnormalized logpdf at the given values of x.

--- a/cuqi/distribution/_truncated_normal.py
+++ b/cuqi/distribution/_truncated_normal.py
@@ -56,7 +56,7 @@ class TruncatedNormal(Distribution):
         else:
             return self._normal.gradient(x)
 
-    def _sample(self,N=1, rng=None):
+    def _sample(self, N=1, rng=None):
         """
         Generates random samples from the distribution.
         """

--- a/cuqi/distribution/_truncated_normal.py
+++ b/cuqi/distribution/_truncated_normal.py
@@ -109,7 +109,7 @@ class TruncatedNormal(Distribution):
         if np.any(x < self.low) or np.any(x > self.high):
             return np.NaN*np.ones_like(x)
         else:
-            return self._normal.gradient(x)
+            return self._normal.gradient(x, *args, **kwargs)
 
     def _sample(self, N=1, rng=None):
         """

--- a/cuqi/distribution/_truncated_normal.py
+++ b/cuqi/distribution/_truncated_normal.py
@@ -34,11 +34,7 @@ class TruncatedNormal(Distribution):
 
         #Generate Normal with mean 0, standard deviation 1 and bounds [-2,2]
         p = cuqi.distribution.TruncatedNormal(mean=0, std=1, low=-2, high=2)
-        sampler = cuqi.experimental.mcmc.MALA(p, scale=0.1)
-        sampler.sample(10000)
-        samples = sampler.get_samples()
-        plt.figure()
-        samples.plot_trace()
+        samples = p.sample(5000)
     """
     def __init__(self, mean=None, std=None, low=-np.Inf, high=np.Inf, is_symmetric=False, **kwargs):
         # Init from abstract distribution class

--- a/cuqi/distribution/_truncated_normal.py
+++ b/cuqi/distribution/_truncated_normal.py
@@ -5,7 +5,14 @@ from cuqi.distribution import Normal
 
 class TruncatedNormal(Distribution):
     """
-    Truncated Normal probability distribution. Generates instance of cuqi.distribution.TruncatedNormal. It allows the user to specify upper and lower bounds on random variables represented by a Normal distribution. This distribution is suitable for a small dimension setup (e.g. `dim`=3 or 4). Using TruncatedNormal Distribution with a larger dimension can lead to a high rejection rate when used within MCMC samplers.
+    Truncated Normal probability distribution.
+    
+    Generates instance of cuqi.distribution.TruncatedNormal. 
+    It allows the user to specify upper and lower bounds on random variables 
+    represented by a Normal distribution. This distribution is suitable for a 
+    small dimension setup (e.g. `dim`=3 or 4). Using TruncatedNormal 
+    Distribution with a larger dimension can lead to a high rejection rate when
+    used within MCMC samplers.
     
     The variables of this distribution are iid.
 

--- a/cuqi/distribution/_truncated_normal.py
+++ b/cuqi/distribution/_truncated_normal.py
@@ -47,7 +47,7 @@ class TruncatedNormal(Distribution):
         self.high = high
 
         # Init underlying normal distribution
-        self._normal = Normal(self.mean, self.std)
+        self._normal = Normal(self.mean, self.std, is_symmetric=is_symmetric, **kwargs)
 
     def logpdf(self, x):
         """
@@ -80,7 +80,7 @@ class TruncatedNormal(Distribution):
         for i in range(int(max_iter)):
             if len(samples) == N:
                 break
-            sample = self._normal.sample()
+            sample = self._normal.sample(1,rng)
             if np.all(sample >= self.low) and np.all(sample <= self.high):
                 samples.append(sample)
         # raise a error if the number of iterations exceeds max_iter

--- a/cuqi/distribution/_truncated_normal.py
+++ b/cuqi/distribution/_truncated_normal.py
@@ -16,7 +16,7 @@ class TruncatedNormal(Distribution):
     a: lower bound of the distribution
     b: upper bound of the distribution
     """
-    def __init__(self, mean=None, std=None, a=-1, b=1, is_symmetric=False, **kwargs):
+    def __init__(self, mean=None, std=None, a=-np.Inf, b=np.Inf, is_symmetric=False, **kwargs):
         # Init from abstract distribution class
         super().__init__(is_symmetric=is_symmetric, **kwargs)  
 

--- a/cuqi/distribution/_truncated_normal.py
+++ b/cuqi/distribution/_truncated_normal.py
@@ -1,0 +1,45 @@
+import numpy as np
+from scipy.special import erf
+from cuqi.distribution import Distribution
+
+class TruncatedNormal(Distribution):
+    """
+    Truncated Normal probability distribution. Generates instance of cuqi.distribution.TruncatedNormal.
+    
+    The variables of this distribution are iid.
+
+    
+    Parameters
+    ------------
+    mean: mean of distribution
+    std: standard deviation
+    a: lower bound of the distribution
+    b: upper bound of the distribution
+    """
+    def __init__(self, mean=None, std=None, a=None, b=None, is_symmetric=False, **kwargs):
+        # Init from abstract distribution class
+        super().__init__(is_symmetric=is_symmetric, **kwargs)  
+
+        # Init specific to this distribution
+        self.mean = mean
+        self.std = std
+        self.a = a
+        self.b = b
+
+    def logpdf(self, x):
+        # the unnormalized logpdf
+        # check if x falls in the range between np.array a and b
+        if np.any(x < self.a) or np.any(x > self.b):
+            return -np.Inf
+        else:
+             return np.sum(-np.log(self.std*np.sqrt(2*np.pi))-0.5*((x-self.mean)/self.std)**2)
+
+    def gradient(self, x):
+        # check if x falls in the range between np.array a and b
+        if np.any(x < self.a) or np.any(x > self.b):
+            return np.NaN*np.ones_like(x)
+        else:
+            return -(x-self.mean)/(self.std**2)
+
+    def _sample(self,N=1, rng=None):
+        pass

--- a/cuqi/distribution/_truncated_normal.py
+++ b/cuqi/distribution/_truncated_normal.py
@@ -15,9 +15,9 @@ class TruncatedNormal(Distribution):
         mean of distribution
     std : float or array_like of floats
         standard deviation
-    a : float or array_like of floats
+    low : float or array_like of floats
         lower bound of the distribution
-    b : float or array_like of floats
+    high : float or array_like of floats
         upper bound of the distribution
     """
     def __init__(self, mean=None, std=None, low=-np.Inf, high=np.Inf, is_symmetric=False, **kwargs):

--- a/cuqi/distribution/_truncated_normal.py
+++ b/cuqi/distribution/_truncated_normal.py
@@ -48,7 +48,7 @@ class TruncatedNormal(Distribution):
         self.high = high
 
         # Init underlying normal distribution
-        self._normal = Normal(self.mean, self.std, is_symmetric=is_symmetric, **kwargs)
+        self._normal = Normal(self.mean, self.std, is_symmetric=True, **kwargs)
 
     @property
     def mean(self):

--- a/cuqi/distribution/_truncated_normal.py
+++ b/cuqi/distribution/_truncated_normal.py
@@ -32,8 +32,13 @@ class TruncatedNormal(Distribution):
     -----------
     .. code-block:: python
 
-        #Generate Normal with mean 0, standard deviation 1 and bounds [-1,1]
-        p = cuqi.distribution.TruncatedNormal(mean=0, std=1, low=-1, high=1)
+        #Generate Normal with mean 0, standard deviation 1 and bounds [-2,2]
+        p = cuqi.distribution.TruncatedNormal(mean=0, std=1, low=-2, high=2)
+        sampler = cuqi.experimental.mcmc.MALA(p, scale=0.1)
+        sampler.sample(10000)
+        samples = sampler.get_samples()
+        plt.figure()
+        samples.plot_trace()
     """
     def __init__(self, mean=None, std=None, low=-np.Inf, high=np.Inf, is_symmetric=False, **kwargs):
         # Init from abstract distribution class

--- a/cuqi/distribution/_truncated_normal.py
+++ b/cuqi/distribution/_truncated_normal.py
@@ -27,6 +27,13 @@ class TruncatedNormal(Distribution):
         lower bound of the distribution
     high : float or array_like of floats
         upper bound of the distribution
+    
+    Example
+    -----------
+    .. code-block:: python
+
+        #Generate Normal with mean 0, standard deviation 1 and bounds [-1,1]
+        p = cuqi.distribution.TruncatedNormal(mean=0, std=1, low=-1, high=1)
     """
     def __init__(self, mean=None, std=None, low=-np.Inf, high=np.Inf, is_symmetric=False, **kwargs):
         # Init from abstract distribution class

--- a/cuqi/distribution/_truncated_normal.py
+++ b/cuqi/distribution/_truncated_normal.py
@@ -101,7 +101,7 @@ class TruncatedNormal(Distribution):
         else:
              return self._normal.logpdf(x)
 
-    def gradient(self, x):
+    def _gradient(self, x, *args, **kwargs):
         """
         Computes the gradient of the unnormalized logpdf at the given values of x.
         """

--- a/cuqi/distribution/_truncated_normal.py
+++ b/cuqi/distribution/_truncated_normal.py
@@ -58,7 +58,8 @@ class TruncatedNormal(Distribution):
     @mean.setter
     def mean(self, value):
         self._mean = force_ndarray(value, flatten=True)
-        self._normal.mean = self._mean
+        if hasattr(self, '_normal'):
+            self._normal.mean = self._mean
 
     @property
     def std(self):
@@ -68,7 +69,8 @@ class TruncatedNormal(Distribution):
     @std.setter
     def std(self, value):
         self._std = force_ndarray(value, flatten=True)
-        self._normal.std = self._std
+        if hasattr(self, '_normal'):
+            self._normal.std = self._std
 
     def logpdf(self, x):
         """

--- a/cuqi/distribution/_truncated_normal.py
+++ b/cuqi/distribution/_truncated_normal.py
@@ -4,7 +4,7 @@ from cuqi.distribution import Distribution
 
 class TruncatedNormal(Distribution):
     """
-    Truncated Normal probability distribution. Generates instance of cuqi.distribution.TruncatedNormal.
+    Truncated Normal probability distribution. Generates instance of cuqi.distribution.TruncatedNormal. It allows the user to specify upper and lower bounds on random variables represented by a Normal distribution. This distribution is suitable for a small dimension setup (e.g. `dim`=3 or 4). Using TruncatedNormal Distribution with a larger dimension can lead to a high rejection rate when used within MCMC samplers.
     
     The variables of this distribution are iid.
 

--- a/cuqi/distribution/_truncated_normal.py
+++ b/cuqi/distribution/_truncated_normal.py
@@ -16,7 +16,7 @@ class TruncatedNormal(Distribution):
     a: lower bound of the distribution
     b: upper bound of the distribution
     """
-    def __init__(self, mean=None, std=None, a=None, b=None, is_symmetric=False, **kwargs):
+    def __init__(self, mean=None, std=None, a=-1, b=1, is_symmetric=False, **kwargs):
         # Init from abstract distribution class
         super().__init__(is_symmetric=is_symmetric, **kwargs)  
 
@@ -42,4 +42,7 @@ class TruncatedNormal(Distribution):
             return -(x-self.mean)/(self.std**2)
 
     def _sample(self,N=1, rng=None):
-        pass
+        """
+        Generates random samples from the distribution.
+        """
+        raise NotImplementedError(f"sample is not implemented for {self.__class__.__name__}.")

--- a/demos/demo38_truncated_normal.py
+++ b/demos/demo38_truncated_normal.py
@@ -29,6 +29,7 @@ plt.xlim(-5, 5)
 plt.ylim(-5, 5)
 plt.gca().set_aspect('equal')
 plt.title("Samples")
+
 # %% Demo 2
 # This demo shows the use of truncted normal as prior in solving the simplest
 # BIP. Here again we use MALA.

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -56,7 +56,7 @@ def test_TruncatedNormal_logpdf(mean,std,low,high,points):
         if np.all(point >= low) and np.all(point <= high):
             assert x_trun.logpdf(point) == approx(x.logpdf(point))
         else:
-            assert np.isinf(x_trun.logpdf(point))
+            assert np.isneginf(x_trun.logpdf(point))
 
 @pytest.mark.parametrize("mean,std,low,high,points",[(0.0, 
                                                1.0,

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -87,6 +87,14 @@ def test_Normal_sample_regression(mean,var,expected):
     target = np.array(expected).T
     assert np.allclose( samples.samples, target)
 
+@pytest.mark.parametrize("mean,std,points,expected",[
+                            (0,1,[-1,0,1],[1,0,-1]),
+   (np.array([0,0]),np.array([1,1]),[[-1,0],[0,0],[0,-1]], [[1,0],[0,0],[0,1]])])
+def test_Normal_gradient(mean,std,points,expected):
+    p = cuqi.distribution.Normal(mean,std)
+    for point, grad in zip(points, expected):
+        assert np.allclose(p.gradient(point), grad)
+
 def test_Gaussian_mean():
     mean = np.array([0, 0])
     std = np.array([1, 1])

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -28,8 +28,7 @@ def test_Normal_pdf_mean():
                                                [np.array([-0.5, 0.0]),
                                                 np.array([0.5, 0.0]),
                                                 np.array([-2.0, 0.0]),
-                                                np.array([2.0, 0.0])]
-                                               )])
+                                                np.array([2.0, 0.0])])])
 def test_TruncatedNormal_logpdf(mean,std,low,high,points):
     x_trun = cuqi.distribution.TruncatedNormal(mean,std,low=low,high=high)
     x = cuqi.distribution.Normal(mean,std)
@@ -51,8 +50,7 @@ def test_TruncatedNormal_logpdf(mean,std,low,high,points):
                                                [np.array([-0.5, 0.0]),
                                                 np.array([0.5, 0.0]),
                                                 np.array([-2.0, 0.0]),
-                                                np.array([2.0, 0.0])]
-                                               )])
+                                                np.array([2.0, 0.0])])])
 def test_TruncatedNormal_gradient(mean,std,low,high,points):
     x_trun = cuqi.distribution.TruncatedNormal(mean,std,low=low,high=high)
     x = cuqi.distribution.Normal(mean,std)
@@ -61,6 +59,21 @@ def test_TruncatedNormal_gradient(mean,std,low,high,points):
             assert np.all(x_trun.gradient(point) == approx(x.gradient(point)))
         else:
             assert np.all(np.isnan(x_trun.gradient(point)))
+
+@pytest.mark.parametrize("mean,std,low,high",[(0.0, 
+                                               1.0,
+                                               -1.0,
+                                               1.0),
+                                              (np.array([0.0, 0.0]), 
+                                               np.array([1.0, 1.0]),
+                                               np.array([-1.0, -1.0]),
+                                               np.array([1.0, 1.0]))])
+def test_TruncatedNormal_sampling(mean,std,low,high):
+    x = cuqi.distribution.TruncatedNormal(mean,std,low=low,high=high)
+    samples = x.sample(10000).samples
+    for i in range(samples.shape[1]):
+        sample = samples[:,i]
+        assert np.all(sample >= low) and np.all(sample <= high)
 
 @pytest.mark.parametrize("mean,var,expected",[
                             (2,3.5,[[8.17418321], [3.40055023]]),

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -16,16 +16,17 @@ def test_Normal_pdf_mean():
     pX = cuqi.distribution.Normal(0.1,1)
     assert pX.pdf(0.1) == approx(1.0/np.sqrt(2.0*np.pi))
 
-@pytest.mark.parametrize("mean,std,low,high,points",[(np.array([0.0]), 
-                                               np.array([1.0]),
-                                               np.array([-1.0]),
-                                               np.array([1.0]),
-                                               [-1.5, 0.0, 1.5]),
+@pytest.mark.parametrize("mean,std,low,high,points",[(0.0, 
+                                               1.0,
+                                               -1.0,
+                                               1.0,
+                                               [-1.5, -0.5, 0.5, 1.5]),
                                               (np.array([0.0, 0.0]), 
                                                np.array([1.0, 1.0]),
                                                np.array([-1.0, -1.0]),
                                                np.array([1.0, 1.0]),
-                                               [np.array([0.0, 0.0]),
+                                               [np.array([-0.5, 0.0]),
+                                                np.array([0.5, 0.0]),
                                                 np.array([-2.0, 0.0]),
                                                 np.array([2.0, 0.0])]
                                                )])
@@ -38,16 +39,17 @@ def test_TruncatedNormal_logpdf(mean,std,low,high,points):
         else:
             assert np.isinf(x_trun.logpdf(point))
 
-@pytest.mark.parametrize("mean,std,low,high,points",[(np.array([0.0]), 
-                                               np.array([1.0]),
-                                               np.array([-1.0]),
-                                               np.array([1.0]),
-                                               [-1.5, 0.0, 1.5]),
+@pytest.mark.parametrize("mean,std,low,high,points",[(0.0, 
+                                               1.0,
+                                               -1.0,
+                                               1.0,
+                                               [-1.5, -0.5, 0.5, 1.5]),
                                               (np.array([0.0, 0.0]), 
                                                np.array([1.0, 1.0]),
                                                np.array([-1.0, -1.0]),
                                                np.array([1.0, 1.0]),
-                                               [np.array([0.0, 0.0]),
+                                               [np.array([-0.5, 0.0]),
+                                                np.array([0.5, 0.0]),
                                                 np.array([-2.0, 0.0]),
                                                 np.array([2.0, 0.0])]
                                                )])

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -16,6 +16,26 @@ def test_Normal_pdf_mean():
     pX = cuqi.distribution.Normal(0.1,1)
     assert pX.pdf(0.1) == approx(1.0/np.sqrt(2.0*np.pi))
 
+@pytest.mark.parametrize("mean,var,expected",[
+                            (2,3.5,[[8.17418321], [3.40055023]]),
+                            (3.141592653589793,2.6457513110645907,[[7.80883646],[4.20030911]]),
+                            (-1e-09, 1000000.0,[[1764052.34596766],[400157.20836722]]),
+                            (1.7724538509055159, 0, [[1.77245385],[1.77245385]])
+                        ])
+def test_Normal_sample_regression(mean,var,expected):
+    rng = np.random.RandomState(0) #Replaces legacy method: np.random.seed(0)
+    samples = cuqi.distribution.Normal(mean,var).sample(2,rng=rng)
+    target = np.array(expected).T
+    assert np.allclose( samples.samples, target)
+
+@pytest.mark.parametrize("mean,std,points,expected",[
+                            (0,1,[-1,0,1],[1,0,-1]),
+   (np.array([0,0]),np.array([1,1]),[[-1,0],[0,0],[0,-1]], [[1,0],[0,0],[0,1]])])
+def test_Normal_gradient(mean,std,points,expected):
+    p = cuqi.distribution.Normal(mean,std)
+    for point, grad in zip(points, expected):
+        assert np.allclose(p.gradient(point), grad)
+
 @pytest.mark.parametrize("mean,std,low,high,points",[(0.0, 
                                                1.0,
                                                -1.0,
@@ -74,26 +94,6 @@ def test_TruncatedNormal_sampling(mean,std,low,high):
     for i in range(samples.shape[1]):
         sample = samples[:,i]
         assert np.all(sample >= low) and np.all(sample <= high)
-
-@pytest.mark.parametrize("mean,var,expected",[
-                            (2,3.5,[[8.17418321], [3.40055023]]),
-                            (3.141592653589793,2.6457513110645907,[[7.80883646],[4.20030911]]),
-                            (-1e-09, 1000000.0,[[1764052.34596766],[400157.20836722]]),
-                            (1.7724538509055159, 0, [[1.77245385],[1.77245385]])
-                        ])
-def test_Normal_sample_regression(mean,var,expected):
-    rng = np.random.RandomState(0) #Replaces legacy method: np.random.seed(0)
-    samples = cuqi.distribution.Normal(mean,var).sample(2,rng=rng)
-    target = np.array(expected).T
-    assert np.allclose( samples.samples, target)
-
-@pytest.mark.parametrize("mean,std,points,expected",[
-                            (0,1,[-1,0,1],[1,0,-1]),
-   (np.array([0,0]),np.array([1,1]),[[-1,0],[0,0],[0,-1]], [[1,0],[0,0],[0,1]])])
-def test_Normal_gradient(mean,std,points,expected):
-    p = cuqi.distribution.Normal(mean,std)
-    for point, grad in zip(points, expected):
-        assert np.allclose(p.gradient(point), grad)
 
 def test_Gaussian_mean():
     mean = np.array([0, 0])

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -16,6 +16,50 @@ def test_Normal_pdf_mean():
     pX = cuqi.distribution.Normal(0.1,1)
     assert pX.pdf(0.1) == approx(1.0/np.sqrt(2.0*np.pi))
 
+@pytest.mark.parametrize("mean,std,low,high,points",[(np.array([0.0]), 
+                                               np.array([1.0]),
+                                               np.array([-1.0]),
+                                               np.array([1.0]),
+                                               [-1.5, 0.0, 1.5]),
+                                              (np.array([0.0, 0.0]), 
+                                               np.array([1.0, 1.0]),
+                                               np.array([-1.0, -1.0]),
+                                               np.array([1.0, 1.0]),
+                                               [np.array([0.0, 0.0]),
+                                                np.array([-2.0, 0.0]),
+                                                np.array([2.0, 0.0])]
+                                               )])
+def test_TruncatedNormal_logpdf(mean,std,low,high,points):
+    x_trun = cuqi.distribution.TruncatedNormal(mean,std,low=low,high=high)
+    x = cuqi.distribution.Normal(mean,std)
+    for point in points:
+        if np.all(point >= low) and np.all(point <= high):
+            assert x_trun.logpdf(point) == approx(x.logpdf(point))
+        else:
+            assert np.isinf(x_trun.logpdf(point))
+
+@pytest.mark.parametrize("mean,std,low,high,points",[(np.array([0.0]), 
+                                               np.array([1.0]),
+                                               np.array([-1.0]),
+                                               np.array([1.0]),
+                                               [-1.5, 0.0, 1.5]),
+                                              (np.array([0.0, 0.0]), 
+                                               np.array([1.0, 1.0]),
+                                               np.array([-1.0, -1.0]),
+                                               np.array([1.0, 1.0]),
+                                               [np.array([0.0, 0.0]),
+                                                np.array([-2.0, 0.0]),
+                                                np.array([2.0, 0.0])]
+                                               )])
+def test_TruncatedNormal_gradient(mean,std,low,high,points):
+    x_trun = cuqi.distribution.TruncatedNormal(mean,std,low=low,high=high)
+    x = cuqi.distribution.Normal(mean,std)
+    for point in points:
+        if np.all(point >= low) and np.all(point <= high):
+            assert np.all(x_trun.gradient(point) == approx(x.gradient(point)))
+        else:
+            assert np.all(np.isnan(x_trun.gradient(point)))
+
 @pytest.mark.parametrize("mean,var,expected",[
                             (2,3.5,[[8.17418321], [3.40055023]]),
                             (3.141592653589793,2.6457513110645907,[[7.80883646],[4.20030911]]),

--- a/tests/test_distributions_shape.py
+++ b/tests/test_distributions_shape.py
@@ -22,7 +22,6 @@ skip_logd = [
 skip_sample = [
     cuqi.distribution.Gamma, # Missing force_ndarray
     cuqi.distribution.Lognormal,
-    cuqi.distribution.TruncatedNormal, # FIXME Missing rng
 ]
 skip_gradient = [
     cuqi.distribution.Gamma, # Missing force_ndarray

--- a/tests/test_distributions_shape.py
+++ b/tests/test_distributions_shape.py
@@ -22,7 +22,7 @@ skip_logd = [
 skip_sample = [
     cuqi.distribution.Gamma, # Missing force_ndarray
     cuqi.distribution.Lognormal,
-    cuqi.distribution.TruncatedNormal, # Seems no easy way to carry rng
+    cuqi.distribution.TruncatedNormal, # FIXME Missing rng
 ]
 skip_gradient = [
     cuqi.distribution.Gamma, # Missing force_ndarray

--- a/tests/test_distributions_shape.py
+++ b/tests/test_distributions_shape.py
@@ -22,6 +22,7 @@ skip_logd = [
 skip_sample = [
     cuqi.distribution.Gamma, # Missing force_ndarray
     cuqi.distribution.Lognormal,
+    cuqi.distribution.TruncatedNormal, # Seems no easy way to carry rng
 ]
 skip_gradient = [
     cuqi.distribution.Gamma, # Missing force_ndarray


### PR DESCRIPTION
fixed #321 to add `TruncatedNormal`
fixed #548 to add `gradient` to `Normal`
fixed #539 to add a demo on `TruncatedNormal`

## Description

- With this PR, we can draw samples from truncated iid normal distributions, i.e., truncated version of `cuqi.distribution.normal` and also use them as priors. 
- Gibbs with a gradient sampler works also fine on it.
- Plots from demo38 can be seen at #549 .

## Test with Gibbs
```python
import cuqi
import numpy as np
np.random.seed(0)
d = cuqi.distribution.Uniform(np.array([0]),np.array([1]))
A = cuqi.model.LinearModel(lambda x: x, adjoint=lambda x: x, range_geometry=1, domain_geometry=1)
x = cuqi.distribution.TruncatedNormal(A(d), std=np.array([1]), low=np.array([-1]), high=np.array([np.Inf]))

sampling_strategy = {
    "d" : cuqi.experimental.mcmc.MALA(initial_point=np.array([0.5]), scale=0.1),
    "x" : cuqi.experimental.mcmc.MALA(initial_point=np.array([1.0]), scale=0.3)
}
joint = cuqi.distribution.JointDistribution(d, x)
sampler = cuqi.experimental.mcmc.HybridGibbs(joint, sampling_strategy=sampling_strategy)
sampler.sample(10000)
samples = sampler.get_samples()
samples["x"].plot_trace()
samples["d"].plot_trace()
```

(Note: here `x` is truncated from -1, just as expected)
![image](https://github.com/user-attachments/assets/0639db0f-8fbe-4f13-b5dd-d91ca7b59b80)
![image](https://github.com/user-attachments/assets/f9427fbc-3300-4037-98d2-d871e9766818)







