### PR TITLE
Add how-to on Image2D

### DIFF
--- a/cuqi/geometry/_geometry.py
+++ b/cuqi/geometry/_geometry.py
@@ -522,6 +522,9 @@ class Image2D(Geometry):
     Plotting is handled via matplotlib.pyplot.imshow.
     Colormap is defaulted to grayscale.
 
+    A How-To guide on the use of Image2D as the domain/range geometry of a CUQI 
+    :class:`Model` is available `here <https://cuqi-dtu.github.io/CUQIpy/user/_auto_howtos/myula.html>`_.
+
     Parameters
     -----------
     im_shape : tuple

--- a/demos/howtos/Image2D.py
+++ b/demos/howtos/Image2D.py
@@ -2,7 +2,7 @@
 The use of Image2D
 ==================
 
-This script demonstrates the use of :class:`~cuqi.geometry.Image2D` for domain and range geometries in CUQIpy forward models. The settings of this geometry, in particular the so-called 'visual_only' flag, depend on how the forward model input is operated on in the forward model. `visual_only` flag tells the geometry to interpret the variable as a 2D image only when visualizing the variable but keep it as a vector when being operated on in the forward model. Generally, if the forward operator expects an image input, set `visual_only` to `False`, which is the default in CUQIpy. Otherwise, if it expects a vector input, set `visual_only` to `True` in the domain geometry. In the same way, the range geometry `visual_only` setting should be consistent with your forward operator output.
+This script demonstrates the use of :class:`~cuqi.geometry.Image2D` for domain and range geometries in CUQIpy forward models. The settings of this geometry, in particular the so-called `visual_only` flag, depend on how the forward model input is operated on in the forward model. `visual_only` flag tells the geometry to interpret the variable as a 2D image only when visualizing the variable but keep it as a vector when being operated on in the forward model. Generally, if the forward operator expects an image input, set `visual_only` to `False`, which is the default in CUQIpy. Otherwise, if it expects a vector input, set `visual_only` to `True` in the domain geometry. In the same way, the range geometry `visual_only` setting should be consistent with your forward operator output.
 """
 
 # %%

--- a/demos/howtos/Image2D.py
+++ b/demos/howtos/Image2D.py
@@ -1,6 +1,6 @@
 """
 The use of Image2D
-=====================================================
+==================
 
 This script demonstrates the use of :class:`~cuqi.distribution.Image2D`. Depending on how the input variable is used in the forward model, the geometry of it can be set to be visual only or not by setting the `visual_only` attribute. Generally, if your forward operator expects a vector input, set `visual_only` to `True`. If it expects an image input, set `visual_only` to `False`, which is the default.
 """
@@ -17,8 +17,8 @@ dim_x, dim_y = 2, 4
 
 # %%
 # Example with `visual_only=False`
-# The underlying structure of a CUQI array or sample will be reshaped to the shape of the specified geometry, i.e., (dim_x, dim_y), before being passed to the model.
-# Here we intend to define a forward operator that downsamples the input image by a factor of 2. It's easier to define the forward operator in terms of an image, so we set `visual_only` to `False`.
+# With `visual_only=False`, the underlying structure of a CUQI array or sample will be reshaped to the shape of the specified geometry, i.e., an image of size (dim_x, dim_y), before being passed to the model.
+# Here we intend to define a forward operator that downsamples the input image by a factor of 2. It's easier to define such a forward operator in terms of an image, so we set `visual_only` to `False`.
 domain_geom_a = cuqi.geometry.Image2D((dim_x, dim_y), visual_only=False)
 range_geom = cuqi.geometry.Image2D((dim_x // 2, dim_y // 2))
 

--- a/demos/howtos/Image2D.py
+++ b/demos/howtos/Image2D.py
@@ -16,10 +16,13 @@ import matplotlib.pyplot as plt
 dim_x, dim_y = 2, 4
 
 # %%
-# Example with `visual_only=False`
-# With `visual_only=False`, the underlying structure of a CUQI array or sample will be reshaped to the shape of the specified geometry, i.e., an image of size (dim_x, dim_y), before being passed to the model.
-# Here we intend to define a forward operator that downsamples the input image by a factor of 2. It's easier to define such a forward operator in terms of an image, so we set `visual_only` to `False`.
-domain_geom_a = cuqi.geometry.Image2D((dim_x, dim_y), visual_only=False)
+# Example illustrating the default behavior: `visual_only=False`
+# With `visual_only=False`, the underlying structure of a CUQI array or sample will be reshaped to the
+# shape of the specified geometry, i.e., an image of size (dim_x, dim_y), before being passed to the model.
+# Here we intend to define a forward operator that downsamples the input image by a factor of 2. It's easier
+# to define such a forward operator in terms of an image. We do not need to explicitly set `visual_only` to 
+#`False` because it is the default behavior.
+domain_geom_a = cuqi.geometry.Image2D((dim_x, dim_y))
 range_geom = cuqi.geometry.Image2D((dim_x // 2, dim_y // 2))
 
 def forward_func_a(image):

--- a/demos/howtos/Image2D.py
+++ b/demos/howtos/Image2D.py
@@ -2,7 +2,7 @@
 The use of Image2D
 ==================
 
-This script demonstrates the use of :class:`~cuqi.geometry.Image2D` for domain and range geometries in CUQIpy forward models. The settings of this geometry, in particular the so-called 'visual_only' flag, depend on how the forward model input is operated on in the forward model. `visual_only` flag tells the geometry to interpret the variable as a 2D image only when visualizing the variable but keep it as a vector when being operated on in the forward model. Generally, if your forward operator expects a vector input, set `visual_only` to `True` in the domain geometry. If it expects an image input, set `visual_only` to `False`, which is the default. In the same way, the range geometry `visual_only` setting should be consistent with your forward operator output.
+This script demonstrates the use of :class:`~cuqi.geometry.Image2D` for domain and range geometries in CUQIpy forward models. The settings of this geometry, in particular the so-called 'visual_only' flag, depend on how the forward model input is operated on in the forward model. `visual_only` flag tells the geometry to interpret the variable as a 2D image only when visualizing the variable but keep it as a vector when being operated on in the forward model. Generally, if the forward operator expects an image input, set `visual_only` to `False`, which is the default in CUQIpy. Otherwise, if it expects a vector input, set `visual_only` to `True` in the domain geometry. In the same way, the range geometry `visual_only` setting should be consistent with your forward operator output.
 """
 
 # %%
@@ -22,41 +22,49 @@ dim_x, dim_y = 2, 4
 # Here we intend to define a forward operator that downsamples the input image by a factor of 2. It's easier
 # to define such a forward operator in terms of an image. We do not need to explicitly set `visual_only` to 
 #`False` because it is the default behavior.
-domain_geom_a = cuqi.geometry.Image2D((dim_x, dim_y))
-range_geom = cuqi.geometry.Image2D((dim_x // 2, dim_y // 2))
 
 def forward_func_a(image):
     assert image.shape == (dim_x, dim_y)
     return image[::2, ::2]
 
-model_A = cuqi.model.LinearModel(forward_func_a, domain_geometry=domain_geom_a, range_geometry=range_geom)
+model_A = cuqi.model.LinearModel(forward_func_a,
+                                 domain_geometry=cuqi.geometry.Image2D((dim_x, dim_y)),
+                                 range_geometry=cuqi.geometry.Image2D((dim_x // 2, dim_y // 2)))
+
 print(model_A)
 
-x_sample = cuqi.array.CUQIarray(np.linspace(0, 1, dim_x * dim_y), geometry=domain_geom_a)
+x_sample = cuqi.array.CUQIarray(np.linspace(0, 1, dim_x * dim_y),
+                                geometry=cuqi.geometry.Image2D((dim_x, dim_y)))
 
 # Plot the original sample
 plt.figure()
 x_sample.plot(cmap='Greens')
-plt.title("X image")
+plt.title("input image x")
 
 # Apply the model and plot the result
 plt.figure()
 y_sample = model_A @ x_sample
 y_sample.plot(cmap='Greens')
-plt.title("Y image (after Model A)")
+plt.title("output y=model_A(x)")
 
 # %%
 # Example with `visual_only=True`
-# With `visual_only=True`, the underlying structure of a cuqi array or sample will not be changed before being passed to the model. This is useful when the model expects a vector input. Here we define a forward operator that reverses the input vector, which can be easily defined in terms of a vector.
+# With `visual_only=True`, the underlying structure of a cuqi array or sample will not be changed before
+# being passed to the model. This is useful when the model expects a vector input. Here we define a 
+# forward operator that reverses the input vector, which can be easily defined in terms of a vector.
 def forward_func_b(x):
     assert x.shape == (dim_x * dim_y, )
     return x[::-1]
 
-model_B = cuqi.model.LinearModel(forward_func_b, domain_geometry=cuqi.geometry.Image2D((dim_x, dim_y), visual_only=True), range_geometry=cuqi.geometry.Image2D((dim_x, dim_y), visual_only=True))
+model_B = cuqi.model.LinearModel(forward_func_b,
+                                 domain_geometry=cuqi.geometry.Image2D((dim_x, dim_y), visual_only=True),
+                                 range_geometry=cuqi.geometry.Image2D((dim_x, dim_y), visual_only=True))
+
+# Note we explicitely set the `visual_only` flag to be `True` here.
 print(model_B)
 
 # Apply the model and plot the result
 plt.figure()
 y_sample = model_B @ x_sample
 y_sample.plot(cmap='Greens')
-plt.title("Y image (after Model B)")
+plt.title("output y=model_B(x)")

--- a/demos/howtos/Image2D.py
+++ b/demos/howtos/Image2D.py
@@ -1,0 +1,59 @@
+"""
+The use of Image2D
+=====================================================
+
+This script demonstrates the use of :class:`~cuqi.distribution.Image2D`. Depending on how the input variable is used in the forward model, the geometry of it can be set to be visual only or not by setting the `visual_only` attribute. Generally, if your forward operator expects a vector input, set `visual_only` to `True`. If it expects an image input, set `visual_only` to `False`, which is the default.
+"""
+
+# %%
+# Import necessary libraries
+import cuqi
+import numpy as np
+import matplotlib.pyplot as plt
+
+# %%
+# Define dimensions
+dim_x, dim_y = 2, 4
+
+# %%
+# Example with `visual_only=False`
+# The underlying structure of a CUQI array or sample will be reshaped to the shape of the specified geometry, i.e., (dim_x, dim_y), before being passed to the model.
+# Here we intend to define a forward operator that downsamples the input image by a factor of 2. It's easier to define the forward operator in terms of an image, so we set `visual_only` to `False`.
+domain_geom_a = cuqi.geometry.Image2D((dim_x, dim_y), visual_only=False)
+range_geom = cuqi.geometry.Image2D((dim_x // 2, dim_y // 2))
+
+def forward_func_a(image):
+    assert image.shape == (dim_x, dim_y)
+    return image[::2, ::2]
+
+model_A = cuqi.model.LinearModel(forward_func_a, domain_geometry=domain_geom_a, range_geometry=range_geom)
+print(model_A)
+
+x_sample = cuqi.array.CUQIarray(np.linspace(0, 1, dim_x * dim_y), geometry=domain_geom_a)
+
+# Plot the original sample
+plt.figure()
+x_sample.plot(cmap='Greens')
+plt.title("X image")
+
+# Apply the model and plot the result
+plt.figure()
+y_sample = model_A @ x_sample
+y_sample.plot(cmap='Greens')
+plt.title("Y image (after Model A)")
+
+# %%
+# Example with `visual_only=True`
+# With `visual_only=True`, the underlying structure of a cuqi array or sample will not be changed before being passed to the model. This is useful when the model expects a vector input. Here we define a forward operator that reverses the input vector, which can be easily defined in terms of a vector.
+def forward_func_b(x):
+    assert x.shape == (dim_x * dim_y, )
+    return x[::-1]
+
+model_B = cuqi.model.LinearModel(forward_func_b, domain_geometry=cuqi.geometry.Image2D((dim_x, dim_y), visual_only=True), range_geometry=cuqi.geometry.Image2D((dim_x, dim_y), visual_only=True))
+print(model_B)
+
+# Apply the model and plot the result
+plt.figure()
+y_sample = model_B @ x_sample
+y_sample.plot(cmap='Greens')
+plt.title("Y image (after Model B)")


### PR DESCRIPTION
fixed #551 

This PR aims to clear some confusion the user might encounter when preparing their forward model. If their forward model works on 2D images, they probably need `visual_only=False` (the default) when defining the domain geometry, and they probably need `visual_only=True` when the model works on vectors.

To deliver this information, this PR added a how-to to demonstrate two use-cases of Image2D:
- visual-only=False for image-based forward operation
- visual-only=True for vector-based forward operation

With this x_sample
![image](https://github.com/user-attachments/assets/25c79df5-2e54-42ff-8cf2-59ddd50fe0ee)

the first case will give output:
![image](https://github.com/user-attachments/assets/a1357202-6af0-429b-9466-93168d95d1da)

while the second will give output:
![image](https://github.com/user-attachments/assets/d31383d5-39d1-487d-a438-11b0613cb141)


