### PR TITLE
Make the interface of restorator more robust

### DIFF
--- a/cuqi/implicitprior/_restorator.py
+++ b/cuqi/implicitprior/_restorator.py
@@ -45,7 +45,7 @@ class RestorationPrior(Distribution):
     def restore(self, x, restoration_strength):
         """This function allows us to restore the input x with the user-supplied
         restorator. Extra information about the restoration operation is stored
-        in the self.info attribute.
+        in the `RestorationPrior` info attribute.
         
         Parameters
         ---------- 

--- a/cuqi/implicitprior/_restorator.py
+++ b/cuqi/implicitprior/_restorator.py
@@ -64,12 +64,11 @@ class RestorationPrior(Distribution):
         if type(restorator_return) == tuple:
             solution, self.info = restorator_return
         else:
-            raise ValueError("The restorator should return a two-element tuple" 
-                             + "with the restored parameter as the first element"
-                             + "and additional information about the restoration"
-                             + "as the second element. As to the second element,"
-                             + "it can be of any type, including `None` in case" 
-                             + "there is no information.")
+            raise ValueError("Wrong return type from the restorator. "+ 
+                             "Please ensure that the restorator returns a two-element tuple with the "+
+                             "restored solution as the first element and additional information about the "+
+                             "restoration as the second element. As to the second element, it can be of any type, "+
+                             "including `None` in case there is no particular information.")
 
         return solution
     

--- a/cuqi/implicitprior/_restorator.py
+++ b/cuqi/implicitprior/_restorator.py
@@ -16,7 +16,8 @@ class RestorationPrior(Distribution):
     ---------- 
     restorator : callable f(x, restoration_strength)
         Function f that accepts input x to be restored and returns the
-        restored version of x and information about the restoration operation.
+        restored version of x or a two-element tuple of the restored version of
+         x and extra information about the restoration operation.
             
     restorator_kwargs : dictionary
         Dictionary containing information about the restorator.
@@ -54,9 +55,14 @@ class RestorationPrior(Distribution):
             restorator is a denoiser, this parameter might correspond to the
             noise level.
         """
-        solution, info = self.restorator(x, restoration_strength=restoration_strength,
+        restorator_return = self.restorator(x,restoration_strength=restoration_strength,
                                          **self.restorator_kwargs)
-        self.info = info
+
+        if type(restorator_return) == tuple:
+            solution, self.info = restorator_return
+        else:
+            solution = restorator_return
+
         return solution
     
     def logpdf(self, x):

--- a/cuqi/implicitprior/_restorator.py
+++ b/cuqi/implicitprior/_restorator.py
@@ -43,10 +43,9 @@ class RestorationPrior(Distribution):
         super().__init__(**kwargs)
 
     def restore(self, x, restoration_strength):
-        """This function allows us to restore the input x and returns a two-element
-        tuple of the restored version of x and some extra information about the
-        restoration operation. The second element can be of any type, including
-        `None` in case there is no particular information.
+        """This function allows us to restore the input x with the user-supplied
+        restorator. Extra information about the restoration operation is stored
+        in the self.info attribute.
         
         Parameters
         ---------- 
@@ -58,7 +57,7 @@ class RestorationPrior(Distribution):
             restorator is a denoiser, this parameter might correspond to the
             noise level.
         """
-        restorator_return = self.restorator(x,restoration_strength=restoration_strength,
+        restorator_return = self.restorator(x, restoration_strength=restoration_strength,
                                          **self.restorator_kwargs)
 
         if type(restorator_return) == tuple and len(restorator_return) == 2:

--- a/cuqi/implicitprior/_restorator.py
+++ b/cuqi/implicitprior/_restorator.py
@@ -15,9 +15,10 @@ class RestorationPrior(Distribution):
     Parameters
     ---------- 
     restorator : callable f(x, restoration_strength)
-        Function f that accepts input x to be restored and returns the
-        restored version of x or a two-element tuple of the restored version of
-         x and extra information about the restoration operation.
+        Function f that accepts input x to be restored and returns a two-element 
+        tuple of the restored version of x and extra information about the 
+        restoration operation. The second element can be of any type, including
+        `None` in case there is no information.
             
     restorator_kwargs : dictionary
         Dictionary containing information about the restorator.
@@ -42,8 +43,10 @@ class RestorationPrior(Distribution):
         super().__init__(**kwargs)
 
     def restore(self, x, restoration_strength):
-        """This function allows us to restore the input x and returns the
-        restored version of x.
+        """This function allows us to restore the input x and returns a two-element
+        tuple of the restored version of x and some extra information about the
+        restoration operation. The second element can be of any type, including
+        `None` in case there is no particular information.
         
         Parameters
         ---------- 
@@ -61,7 +64,12 @@ class RestorationPrior(Distribution):
         if type(restorator_return) == tuple:
             solution, self.info = restorator_return
         else:
-            solution = restorator_return
+            raise ValueError("The restorator should return a two-element tuple" 
+                             + "with the restored parameter as the first element"
+                             + "and additional information about the restoration"
+                             + "as the second element. As to the second element,"
+                             + "it can be of any type, including `None` in case" 
+                             + "there is no information.")
 
         return solution
     

--- a/cuqi/implicitprior/_restorator.py
+++ b/cuqi/implicitprior/_restorator.py
@@ -63,10 +63,10 @@ class RestorationPrior(Distribution):
         if type(restorator_return) == tuple and len(restorator_return) == 2:
             solution, self.info = restorator_return
         else:
-            raise ValueError("Wrong return type from the restorator. "+ 
-                             "Please ensure that the restorator returns a two-element tuple with the "+
+            raise ValueError("Unsupported return type from the user-supplied restorator function. "+ 
+                             "Please ensure that the restorator function returns a two-element tuple with the "+
                              "restored solution as the first element and additional information about the "+
-                             "restoration as the second element. As to the second element, it can be of any type, "+
+                             "restoration as the second element. The second element can be of any type, "+
                              "including `None` in case there is no particular information.")
 
         return solution

--- a/cuqi/implicitprior/_restorator.py
+++ b/cuqi/implicitprior/_restorator.py
@@ -61,7 +61,7 @@ class RestorationPrior(Distribution):
         restorator_return = self.restorator(x,restoration_strength=restoration_strength,
                                          **self.restorator_kwargs)
 
-        if type(restorator_return) == tuple:
+        if type(restorator_return) == tuple and len(restorator_return) == 2:
             solution, self.info = restorator_return
         else:
             raise ValueError("Wrong return type from the restorator. "+ 

--- a/tests/test_implicit_priors.py
+++ b/tests/test_implicit_priors.py
@@ -28,7 +28,7 @@ def test_RegularizedGaussian_guarding_statements():
 
     with pytest.raises(ValueError, match="Projector should take 1 argument"):
         cuqi.implicitprior.RegularizedGaussian(np.zeros(5), 1, projector=lambda s,z: s)
-        
+
 def test_creating_restorator():
     """ Test creating the object from restorator class."""
 
@@ -38,6 +38,32 @@ def test_creating_restorator():
     assert np.allclose(restorator.restore(np.ones(4), 0.1), np.ones(4))
     assert restorator.info == True
 
+def test_handling_invalid_restorator():
+    """ Test handling invalid restorator."""
+    # Invalid return type 1: None
+    def func_1(x, restoration_strength=0.1):
+        return
+    restore_prior_1 = cuqi.implicitprior.RestorationPrior(func_1)
+    with pytest.raises(ValueError, match=r"Wrong return type .*"):
+        restore_prior_1.restore(np.ones(4), 0.1)
+    # Invalid return type 2: one parameter
+    def func_2(x, restoration_strength=0.1):
+        return x
+    restore_prior_2 = cuqi.implicitprior.RestorationPrior(func_2)
+    with pytest.raises(ValueError, match=r"Wrong return type .*"):
+        restore_prior_2.restore(np.ones(4), 0.1)
+    # Invalid return type 3: tuple with 3 elements
+    def func_3(x, restoration_strength=0.1):
+        return x, None, False
+    restore_prior_3 = cuqi.implicitprior.RestorationPrior(func_3)
+    with pytest.raises(ValueError, match=r"Wrong return type .*"):
+        restore_prior_3.restore(np.ones(4), 0.1)
+    # Invalid return type 4: list with 2 elements
+    def func_4(x, restoration_strength=0.1):
+        return [x, None]
+    restore_prior_4 = cuqi.implicitprior.RestorationPrior(func_4)
+    with pytest.raises(ValueError, match=r"Wrong return type .*"):
+        restore_prior_4.restore(np.ones(4), 0.1)
 
 def test_creating_restorator_with_potential():
     """ Test creating the object from restorator class with a potential."""

--- a/tests/test_implicit_priors.py
+++ b/tests/test_implicit_priors.py
@@ -44,25 +44,25 @@ def test_handling_invalid_restorator():
     def func_1(x, restoration_strength=0.1):
         return
     restore_prior_1 = cuqi.implicitprior.RestorationPrior(func_1)
-    with pytest.raises(ValueError, match=r"Wrong return type .*"):
+    with pytest.raises(ValueError, match=r"Unsupported return type .*"):
         restore_prior_1.restore(np.ones(4), 0.1)
     # Invalid return type 2: one parameter
     def func_2(x, restoration_strength=0.1):
         return x
     restore_prior_2 = cuqi.implicitprior.RestorationPrior(func_2)
-    with pytest.raises(ValueError, match=r"Wrong return type .*"):
+    with pytest.raises(ValueError, match=r"Unsupported return type .*"):
         restore_prior_2.restore(np.ones(4), 0.1)
     # Invalid return type 3: tuple with 3 elements
     def func_3(x, restoration_strength=0.1):
         return x, None, False
     restore_prior_3 = cuqi.implicitprior.RestorationPrior(func_3)
-    with pytest.raises(ValueError, match=r"Wrong return type .*"):
+    with pytest.raises(ValueError, match=r"Unsupported return type .*"):
         restore_prior_3.restore(np.ones(4), 0.1)
     # Invalid return type 4: list with 2 elements
     def func_4(x, restoration_strength=0.1):
         return [x, None]
     restore_prior_4 = cuqi.implicitprior.RestorationPrior(func_4)
-    with pytest.raises(ValueError, match=r"Wrong return type .*"):
+    with pytest.raises(ValueError, match=r"Unsupported return type .*"):
         restore_prior_4.restore(np.ones(4), 0.1)
 
 def test_creating_restorator_with_potential():


### PR DESCRIPTION
fixed #588 

- add more documentation  on the required return type of the user-supplied `restorator`
- raise value error if the `restorator` doesn't return a tuple of length 2