### PR TITLE
Regularized Gaussian: Combined regularized and constraint presets

### DIFF
--- a/cuqi/experimental/mcmc/_conjugate.py
+++ b/cuqi/experimental/mcmc/_conjugate.py
@@ -266,6 +266,7 @@ class _RegularizedGaussianModifiedHalfNormalPair(_ConjugatePair):
     
 
 def _compute_sparsity_level(target):
+    """Computes the sparsity level in accordance with Section 4 from [2],"""
     x = target.likelihood.data
     if target.likelihood.distribution.preset["constraint"] == "nonnegativity":
         if target.likelihood.distribution.preset["regularization"] == "l1":
@@ -274,7 +275,7 @@ def _compute_sparsity_level(target):
             m = count_constant_components_1D(x, lower = 0.0)
         elif target.likelihood.distribution.preset["regularization"] == "tv" and isinstance(target.likelihood.distribution.geometry, (Continuous2D, Image2D)):
             m = count_constant_components_2D(target.likelihood.distribution.geometry.par2fun(x), lower = 0.0)
-    else:
+    else: # No constraints, only regularization
         if target.likelihood.distribution.preset["regularization"] == "l1":
             m = count_nonzero(x)
         elif target.likelihood.distribution.preset["regularization"] == "tv" and isinstance(target.likelihood.distribution.geometry, Continuous1D):

--- a/cuqi/experimental/mcmc/_conjugate.py
+++ b/cuqi/experimental/mcmc/_conjugate.py
@@ -147,7 +147,7 @@ class _RegularizedGaussianGammaPair(_ConjugatePair):
         if self.target.prior.dim != 1:
             raise ValueError("RegularizedGaussian-Gamma conjugacy only works with univariate ModifiedHalfNormal prior")
 
-        if self.target.likelihood.distribution.preset not in ["nonnegativity"]:
+        if self.target.likelihood.distribution.preset["constraint"] not in ["nonnegativity"]:
             raise ValueError("RegularizedGaussian-Gamma conjugacy only works with implicit regularized Gaussian likelihood with nonnegativity constraints")
 
         key_value_pairs = _get_conjugate_parameter(self.target)
@@ -183,7 +183,7 @@ class _RegularizedUnboundedUniformGammaPair(_ConjugatePair):
         if self.target.prior.dim != 1:
             raise ValueError("RegularizedUnboundedUniform-Gamma conjugacy only works with univariate Gamma prior")
         
-        if self.target.likelihood.distribution.preset not in ["l1", "tv"]:
+        if self.target.likelihood.distribution.preset["regularization"] not in ["l1", "tv"]:
             raise ValueError("RegularizedUnboundedUniform-Gamma conjugacy only works with implicit regularized Gaussian likelihood with l1 or tv regularization")
         
         key_value_pairs = _get_conjugate_parameter(self.target)
@@ -203,12 +203,7 @@ class _RegularizedUnboundedUniformGammaPair(_ConjugatePair):
 
         # Compute likelihood quantities
         x = self.target.likelihood.data
-        if self.target.likelihood.distribution.preset == "l1":
-            m = count_nonzero(x)
-        elif self.target.likelihood.distribution.preset == "tv" and isinstance(self.target.likelihood.distribution.geometry, Continuous1D):
-            m = count_constant_components_1D(x)
-        elif self.target.likelihood.distribution.preset == "tv" and isinstance(self.target.likelihood.distribution.geometry, (Continuous2D, Image2D)):
-            m = count_constant_components_2D(self.target.likelihood.distribution.geometry.par2fun(x))
+        m = _compute_sparsity_level(self.target)
 
         reg_op = self.target.likelihood.distribution._regularization_oper
         reg_strength = self.target.likelihood.distribution(np.array([1])).strength
@@ -224,7 +219,7 @@ class _RegularizedGaussianModifiedHalfNormalPair(_ConjugatePair):
         if self.target.prior.dim != 1:
             raise ValueError("RegularizedGaussian-ModifiedHalfNormal conjugacy only works with univariate ModifiedHalfNormal prior")
         
-        if self.target.likelihood.distribution.preset not in ["l1", "tv"]:
+        if self.target.likelihood.distribution.preset["regularization"] not in ["l1", "tv"]:
             raise ValueError("RegularizedGaussian-ModifiedHalfNormal conjugacy only works with implicit regularized Gaussian likelihood with l1 or tv regularization")
 
         key_value_pairs = _get_conjugate_parameter(self.target)
@@ -254,13 +249,8 @@ class _RegularizedGaussianModifiedHalfNormalPair(_ConjugatePair):
         x = self.target.likelihood.data
         mu = self.target.likelihood.distribution.mean
         L = self.target.likelihood.distribution(np.array([1])).sqrtprec
-
-        if self.target.likelihood.distribution.preset == "l1":
-            m = count_nonzero(x)
-        elif self.target.likelihood.distribution.preset == "tv" and isinstance(self.target.likelihood.distribution.geometry, Continuous1D):
-            m = count_constant_components_1D(x)
-        elif self.target.likelihood.distribution.preset == "tv" and isinstance(self.target.likelihood.distribution.geometry, (Continuous2D, Image2D)):
-            m = count_constant_components_2D(self.target.likelihood.distribution.geometry.par2fun(x))
+        
+        m = _compute_sparsity_level(self.target)
 
         reg_op = self.target.likelihood.distribution._regularization_oper
         reg_strength = self.target.likelihood.distribution(np.array([1])).strength
@@ -274,6 +264,25 @@ class _RegularizedGaussianModifiedHalfNormalPair(_ConjugatePair):
         # Create conjugate distribution
         return ModifiedHalfNormal(conj_alpha, conj_beta, conj_gamma)
     
+
+def _compute_sparsity_level(target):
+    x = target.likelihood.data
+    if target.likelihood.distribution.preset["constraint"] == "nonnegativity":
+        if target.likelihood.distribution.preset["regularization"] == "l1":
+            m = count_nonzero(x)
+        elif target.likelihood.distribution.preset["regularization"] == "tv" and isinstance(target.likelihood.distribution.geometry, Continuous1D):
+            m = count_constant_components_1D(x, lower = 0.0)
+        elif target.likelihood.distribution.preset["regularization"] == "tv" and isinstance(target.likelihood.distribution.geometry, (Continuous2D, Image2D)):
+            m = count_constant_components_2D(target.likelihood.distribution.geometry.par2fun(x), lower = 0.0)
+    else:
+        if target.likelihood.distribution.preset["regularization"] == "l1":
+            m = count_nonzero(x)
+        elif target.likelihood.distribution.preset["regularization"] == "tv" and isinstance(target.likelihood.distribution.geometry, Continuous1D):
+            m = count_constant_components_1D(x)
+        elif target.likelihood.distribution.preset["regularization"] == "tv" and isinstance(target.likelihood.distribution.geometry, (Continuous2D, Image2D)):
+            m = count_constant_components_2D(target.likelihood.distribution.geometry.par2fun(x))
+    return m
+
 
 def _get_conjugate_parameter(target):
     """Extract the conjugate parameter name (e.g. d), and returns the mutable variable that is defined by the conjugate parameter, e.g. cov and its value e.g. lambda d:1/d"""

--- a/cuqi/experimental/mcmc/_rto.py
+++ b/cuqi/experimental/mcmc/_rto.py
@@ -239,7 +239,7 @@ class RegularizedLinearRTO(LinearRTO):
     @solver.setter
     def solver(self, value):
         if value == "ScipyLinearLSQ":
-            if (self.target.prior._preset == "nonnegativity" or self.target.prior._preset == "box"):
+            if (self.target.prior.preset["constraint"] == "nonnegativity" or self.target.prior.preset["constraint"] == "box"):
                 self._solver = value
             else:
                 raise ValueError("ScipyLinearLSQ only supports RegularizedGaussian with box or nonnegativity constraint.")

--- a/cuqi/implicitprior/_regularizedGMRF.py
+++ b/cuqi/implicitprior/_regularizedGMRF.py
@@ -68,6 +68,7 @@ class RegularizedGMRF(RegularizedGaussian):
             # Init from abstract distribution class
             super(Distribution, self).__init__(**kwargs)
 
+            self._force_list = False
             self._parse_regularization_input_arguments(proximal, projector, constraint, regularization, args)
 
 

--- a/cuqi/implicitprior/_regularizedGaussian.py
+++ b/cuqi/implicitprior/_regularizedGaussian.py
@@ -117,15 +117,17 @@ class RegularizedGaussian(Distribution):
             if callable(proximal):
                 if len(get_non_default_args(proximal)) != 2:
                     raise ValueError("Proximal should take 2 arguments.")
-            else:
+            elif isinstance(proximal, list):
                 pass # TODO: Add error checking for list of regularizations
+            else:
+                raise ValueError("Proximal needs to be callable or a list. See documentation.")
             
         if projector is not None:
             if callable(projector):
                 if len(get_non_default_args(projector)) != 1:
                     raise ValueError("Projector should take 1 argument.")
             else:
-                pass # TODO: Add error checking for list of regularizations
+                raise ValueError("Projector needs to be callable")
             
         # Set user-defined proximals or projectors
         if proximal is not None:

--- a/cuqi/implicitprior/_regularizedGaussian.py
+++ b/cuqi/implicitprior/_regularizedGaussian.py
@@ -134,7 +134,7 @@ class RegularizedGaussian(Distribution):
                             raise ValueError("Proximal should take 2 arguments.")
                     else:
                         raise ValueError("Proximal operators need to be callable.")
-                    if not isinstance(val[1], (np.ndarray, sp.sparray, sp.linalg.LinearOperator)):
+                    if not isinstance(val[1], (np.ndarray, sparse.sparray, sparse.linalg.LinearOperator)):
                         raise ValueError("Linear operator not supported.")
 
             else:

--- a/cuqi/implicitprior/_regularizedGaussian.py
+++ b/cuqi/implicitprior/_regularizedGaussian.py
@@ -49,6 +49,8 @@ class RegularizedGaussian(Distribution):
             min_z 0.5||x-z||_2^2+scale*g(x).
         If list of tuples (callable proximal operator of f_i, linear operator L_i):
             Each callable proximal operator of f_i accepts two arguments (x, p) and should return the minimizer of p/2||x-z||^2 + f(x) over z for some f.
+            Each linear operator needs to have the '__matmul__', 'T' and 'shape' attributes;
+            this includes numpy.ndarray, scipy.sparse.sparray, scipy.sparse.linalg.LinearOperator and cuqi.operator.Operator.
             The corresponding regularization takes the form
                 sum_i f_i(L_i x),
             where the sum ranges from 1 to an arbitrary n.

--- a/cuqi/implicitprior/_regularizedGaussian.py
+++ b/cuqi/implicitprior/_regularizedGaussian.py
@@ -2,7 +2,7 @@ from cuqi.utilities import get_non_default_args
 from cuqi.distribution import Distribution, Gaussian
 from cuqi.solver import ProjectNonnegative, ProjectBox, ProximalL1
 from cuqi.geometry import Continuous1D, Continuous2D, Image2D
-from cuqi.operator import FirstOrderFiniteDifference
+from cuqi.operator import FirstOrderFiniteDifference, Operator
 
 import numpy as np
 import scipy.sparse as sparse
@@ -134,7 +134,7 @@ class RegularizedGaussian(Distribution):
                             raise ValueError("Proximal should take 2 arguments.")
                     else:
                         raise ValueError("Proximal operators need to be callable.")
-                    if not isinstance(val[1], (np.ndarray, sparse.sparray, sparse.linalg.LinearOperator)):
+                    if not isinstance(val[1], (np.ndarray, sparse.sparray, sparse.linalg.LinearOperator, Operator)):
                         raise ValueError("Linear operator not supported.")
 
             else:

--- a/cuqi/implicitprior/_regularizedGaussian.py
+++ b/cuqi/implicitprior/_regularizedGaussian.py
@@ -162,10 +162,10 @@ class RegularizedGaussian(Distribution):
                 self._box_bounds = (np.ones(self.dim)*0, np.ones(self.dim)*np.inf)
                 self._preset["constraint"] = "nonnegativity"
             elif c_lower == "box":
-                self._box_lower = optional_regularization_parameters["lower_bound"]
-                self._box_upper = optional_regularization_parameters["upper_bound"]
-                self._proximal = lambda z, _: ProjectBox(z, self._box_lower, self._box_upper)
-                self._box_bounds = (np.ones(self.dim)*self._box_lower, np.ones(self.dim)*self._box_upper)
+                _box_lower = optional_regularization_parameters["lower_bound"]
+                _box_upper = optional_regularization_parameters["upper_bound"]
+                self._proximal = lambda z, _: ProjectBox(z, _box_lower, _box_upper)
+                self._box_bounds = (np.ones(self.dim)*_box_lower, np.ones(self.dim)*_box_upper)
                 self._preset["constraint"] = "box"
             else:
                 raise ValueError("Constraint not supported.")
@@ -185,12 +185,10 @@ class RegularizedGaussian(Distribution):
                 self._preset["regularization"] = "l1"
             elif r_lower == "tv":
                 # Store the transformation to reuse when modifying the strength
-                if isinstance(self.geometry, (Continuous1D, Continuous2D, Image2D)):
-                    self._transformation = FirstOrderFiniteDifference(self.geometry.fun_shape, bc_type='neumann')
-                else:
+                if not isinstance(self.geometry, (Continuous1D, Continuous2D, Image2D)):
                     raise ValueError("Geometry not supported for total variation")
                 self._regularization_prox = lambda z, gamma: ProximalL1(z, gamma*self._strength)
-                self._regularization_oper = self._transformation
+                self._regularization_oper = FirstOrderFiniteDifference(self.geometry.fun_shape, bc_type='neumann')
                 self._preset["regularization"] = "tv"
             else:
                 raise ValueError("Regularization not supported.")

--- a/cuqi/implicitprior/_regularizedGaussian.py
+++ b/cuqi/implicitprior/_regularizedGaussian.py
@@ -109,7 +109,15 @@ class RegularizedGaussian(Distribution):
         if (proximal is not None) + (projector is not None) >= 1:
             self._parse_user_specified_input(proximal, projector)
         else:
-            self._parse_preset_input(constraint, regularization, optional_regularization_parameters)
+            # Set constraint and regularization presets for use with Gibbs
+            self._preset = {"constraint": None,
+                            "regularization": None}
+
+            self._parse_preset_constraint_input(constraint, optional_regularization_parameters)
+            self._parse_preset_regularization_input(regularization, optional_regularization_parameters)
+
+            # Merge
+            self._merge_predefined_option()
 
     def _parse_user_specified_input(self, proximal, projector):
         # Guard for checking partial validy of proximals or projectors
@@ -140,11 +148,7 @@ class RegularizedGaussian(Distribution):
             self._proximal = lambda z, gamma: projector(z)
             return
 
-    def _parse_preset_input(self, constraint, regularization, optional_regularization_parameters):
-        # Set constraint and regularization presets for use with Gibbs
-        self._preset = {"constraint": None,
-                        "regularization": None}
-
+    def _parse_preset_constraint_input(self, constraint, optional_regularization_parameters):
         # Create data for constraints
         self._constraint_prox = None
         self._constraint_oper = None
@@ -166,6 +170,7 @@ class RegularizedGaussian(Distribution):
             else:
                 raise ValueError("Constraint not supported.")
 
+    def _parse_preset_regularization_input(self, regularization, optional_regularization_parameters):
         # Create data for regularization
         self._regularization_prox = None
         self._regularization_oper = None
@@ -189,10 +194,6 @@ class RegularizedGaussian(Distribution):
                 self._preset["regularization"] = "tv"
             else:
                 raise ValueError("Regularization not supported.")
-                
-        # Merge
-        self._merge_predefined_option()
-
     
     def _merge_predefined_option(self):
         # Check whether it is a single proximal and hence FISTA could be used in RegularizedLinearRTO 

--- a/cuqi/implicitprior/_regularizedGaussian.py
+++ b/cuqi/implicitprior/_regularizedGaussian.py
@@ -134,9 +134,8 @@ class RegularizedGaussian(Distribution):
                             raise ValueError("Proximal should take 2 arguments.")
                     else:
                         raise ValueError("Proximal operators need to be callable.")
-                    if not isinstance(val[1], (np.ndarray, sparse.sparray, sparse.linalg.LinearOperator, Operator)):
-                        raise ValueError("Linear operator not supported.")
-
+                    if not (hasattr(val[1], '__matmul__') and hasattr(val[1], 'T') and hasattr(val[1], 'shape')):
+                        raise ValueError("Linear operator not supported, must have '__matmul__', 'T' and 'shape' attributes.")
             else:
                 raise ValueError("Proximal needs to be callable or a list. See documentation.")
             

--- a/cuqi/implicitprior/_regularizedGaussian.py
+++ b/cuqi/implicitprior/_regularizedGaussian.py
@@ -130,7 +130,7 @@ class RegularizedGaussian(Distribution):
                     if len(val) != 2:
                         raise ValueError("Each value in the proximal list needs to consistent of two elements: a proximal operator and a linear operator.")
                     if callable(val[0]):
-                        if len(get_non_default_args(proximal)) != 2:
+                        if len(get_non_default_args(val[0])) != 2:
                             raise ValueError("Proximal should take 2 arguments.")
                     else:
                         raise ValueError("Proximal operators need to be callable.")

--- a/cuqi/implicitprior/_regularizedGaussian.py
+++ b/cuqi/implicitprior/_regularizedGaussian.py
@@ -103,7 +103,7 @@ class RegularizedGaussian(Distribution):
             raise ValueError("Only one of proximal or projector can be used.")
 
         if (proximal is not None) + (projector is not None) + max((constraint is not None), (regularization is not None)) > 1:
-            raise ValueError("User-defined proximals an projectors cannot be combined with pre-defined constraints and regularization.")
+            raise ValueError("User-defined proximals and projectors cannot be combined with pre-defined constraints and regularization.")
 
         # Branch between user-defined and preset
         if (proximal is not None) + (projector is not None) >= 1:

--- a/cuqi/implicitprior/_regularizedGaussian.py
+++ b/cuqi/implicitprior/_regularizedGaussian.py
@@ -97,7 +97,7 @@ class RegularizedGaussian(Distribution):
 
         # Guards checking whether the regularization inputs are valid
         if (proximal is not None) + (projector is not None) + max((constraint is not None), (regularization is not None)) == 0:
-            raise ValueError("At least some constraint or regularization has to be specified.")
+            raise ValueError("At least some constraint or regularization has to be specified for RegularizedGaussian")
             
         if (proximal is not None) + (projector is not None) == 2:
             raise ValueError("Only one of proximal or projector can be used.")

--- a/cuqi/implicitprior/_regularizedGaussian.py
+++ b/cuqi/implicitprior/_regularizedGaussian.py
@@ -126,7 +126,17 @@ class RegularizedGaussian(Distribution):
                 if len(get_non_default_args(proximal)) != 2:
                     raise ValueError("Proximal should take 2 arguments.")
             elif isinstance(proximal, list):
-                pass # TODO: Add error checking for list of regularizations
+                for val in proximal:
+                    if len(val) != 2:
+                        raise ValueError("Each value in the proximal list needs to consistent of two elements: a proximal operator and a linear operator.")
+                    if callable(val[0]):
+                        if len(get_non_default_args(proximal)) != 2:
+                            raise ValueError("Proximal should take 2 arguments.")
+                    else:
+                        raise ValueError("Proximal operators need to be callable.")
+                    if not isinstance(val[1], (np.ndarray, sp.sparray, sp.linalg.LinearOperator)):
+                        raise ValueError("Linear operator not supported.")
+
             else:
                 raise ValueError("Proximal needs to be callable or a list. See documentation.")
             

--- a/cuqi/implicitprior/_regularizedUnboundedUniform.py
+++ b/cuqi/implicitprior/_regularizedUnboundedUniform.py
@@ -63,4 +63,5 @@ class RegularizedUnboundedUniform(RegularizedGaussian):
                 # Init from abstract distribution class
                 super(Distribution, self).__init__(**kwargs)
 
+                self._force_list = False
                 self._parse_regularization_input_arguments(proximal, projector, constraint, regularization, args)

--- a/cuqi/sampler/_conjugate.py
+++ b/cuqi/sampler/_conjugate.py
@@ -28,7 +28,7 @@ class Conjugate: # TODO: Subclass from Sampler once updated
         if not target.prior.dim == 1:
             raise ValueError("Conjugate sampler only works with univariate Gamma prior")
             
-        if isinstance(target.likelihood.distribution, (RegularizedGaussian, RegularizedGMRF)) and (target.likelihood.distribution.preset["constraints"] not in ["nonnegativity"] or target.likelihood.distribution.preset["regularization"] is not None) :
+        if isinstance(target.likelihood.distribution, (RegularizedGaussian, RegularizedGMRF)) and (target.likelihood.distribution.preset["constraint"] not in ["nonnegativity"] or target.likelihood.distribution.preset["regularization"] is not None) :
                raise ValueError("Conjugate sampler only works implicit regularized Gaussian likelihood with nonnegativity constraints")
         
         self.target = target

--- a/cuqi/sampler/_conjugate.py
+++ b/cuqi/sampler/_conjugate.py
@@ -28,7 +28,7 @@ class Conjugate: # TODO: Subclass from Sampler once updated
         if not target.prior.dim == 1:
             raise ValueError("Conjugate sampler only works with univariate Gamma prior")
             
-        if isinstance(target.likelihood.distribution, (RegularizedGaussian, RegularizedGMRF)) and target.likelihood.distribution.preset not in ["nonnegativity"]:
+        if isinstance(target.likelihood.distribution, (RegularizedGaussian, RegularizedGMRF)) and (target.likelihood.distribution.preset["constraints"] not in ["nonnegativity"] or target.likelihood.distribution.preset["regularization"] is not None) :
                raise ValueError("Conjugate sampler only works implicit regularized Gaussian likelihood with nonnegativity constraints")
         
         self.target = target

--- a/tests/test_implicit_priors.py
+++ b/tests/test_implicit_priors.py
@@ -5,14 +5,14 @@ import pytest
 def test_RegularizedGaussian_default_init():
     """ Test that the implicit regularized Gaussian requires at least 1 regularization argument """
 
-    with pytest.raises(ValueError, match="Precisely one of "):
+    with pytest.raises(ValueError, match="At least some "):
         x = cuqi.implicitprior.RegularizedGaussian(np.zeros(5), 1)
 
 def test_RegularizedGaussian_guarding_statements():
     """ Test that we catch incorrect initialization of RegularizedGaussian """
 
     # More than 1 argument
-    with pytest.raises(ValueError, match="Precisely one of "):
+    with pytest.raises(ValueError, match="User-defined proximals and "):
         cuqi.implicitprior.RegularizedGaussian(np.zeros(5), 1, proximal=lambda s,z: s, constraint="nonnegativity")
 
     # Proximal

--- a/tests/test_implicit_priors.py
+++ b/tests/test_implicit_priors.py
@@ -175,7 +175,7 @@ def test_RegularizedGaussian_double_preset():
     constraint = "nonnegativity"
     regularization = "tv"
     x = cuqi.implicitprior.RegularizedGaussian(np.zeros(5), 1,
-                                                regularization = "tv", strength = 5,
+                                                regularization = regularization, strength = 5,
                                                 constraint = constraint)
 
     # Check that the correct presets are set

--- a/tests/test_implicit_priors.py
+++ b/tests/test_implicit_priors.py
@@ -168,3 +168,20 @@ def test_RegularizedGaussian_conditioning_strength():
     assert np.allclose(x.mean, [1, 1, 1, 1])
     assert np.allclose(x.prec, 10)
     assert np.allclose(x.strength, 6)
+
+def test_RegularizedGaussian_double_preset():
+    """ Test that the implicit RegularizedGaussian can handle combined regularization and constraint presets """
+
+    constraint = "nonnegativity"
+    regularization = "tv"
+    x = cuqi.implicitprior.RegularizedGaussian(np.zeros(5), 1,
+                                                regularization = "tv", strength = 5,
+                                                constraint = constraint)
+
+    # Check that the correct presets are set
+    assert x.preset["constraint"] == constraint
+    assert x.preset["regularization"] == regularization
+    # Check whether the constructed proximal list is of correct size
+    assert len(x.proximal) == 2
+    assert len(x.proximal[0]) == 2
+    assert len(x.proximal[1]) == 2

--- a/tests/test_implicit_priors.py
+++ b/tests/test_implicit_priors.py
@@ -97,7 +97,8 @@ def test_ConstrainedGaussian_alias():
     x = cuqi.implicitprior.ConstrainedGaussian(np.zeros(5), 1, constraint="nonnegativity")
 
     assert isinstance(x, cuqi.implicitprior.RegularizedGaussian)
-    assert x.preset == "nonnegativity"
+    assert x.preset["constraint"] == "nonnegativity"
+    assert x.preset["regularization"] is None
 
 def test_NonnegativeGaussian_alias():
     """ Test that the implicit nonnegative Gaussian is a correct allias for an implicit regularized Gaussian """
@@ -105,7 +106,8 @@ def test_NonnegativeGaussian_alias():
     x = cuqi.implicitprior.NonnegativeGaussian(np.zeros(5), 1)
 
     assert isinstance(x, cuqi.implicitprior.RegularizedGaussian)
-    assert x.preset == "nonnegativity"
+    assert x.preset["constraint"] == "nonnegativity"
+    assert x.preset["regularization"] is None
 
 def test_ConstrainedGMRF_alias():
     """ Test that the implicit constrained GMRF is a correct allias for an implicit regularized GMRF """
@@ -113,7 +115,8 @@ def test_ConstrainedGMRF_alias():
     x = cuqi.implicitprior.ConstrainedGMRF(np.zeros(5), 1, constraint="nonnegativity")
 
     assert isinstance(x, cuqi.implicitprior.RegularizedGMRF)
-    assert x.preset == "nonnegativity"
+    assert x.preset["constraint"] == "nonnegativity"
+    assert x.preset["regularization"] is None
 
 def test_NonnegativeGMRF_alias():
     """ Test that the implicit nonnegative GMRF is a correct allias for an implicit regularized GMRF """
@@ -121,7 +124,8 @@ def test_NonnegativeGMRF_alias():
     x = cuqi.implicitprior.NonnegativeGMRF(np.zeros(5), 1)
 
     assert isinstance(x, cuqi.implicitprior.RegularizedGMRF)
-    assert x.preset == "nonnegativity"
+    assert x.preset["constraint"] == "nonnegativity"
+    assert x.preset["regularization"] is None
 
 def test_RegularizedUnboundedUniform_is_RegularizedGaussian():
     """ Test that the implicit regularized unbounded uniform create a Regularized Gaussian with zero sqrtprec """


### PR DESCRIPTION
Part of #585 

Allows the user to specify both a regularization and constraint preset, e.g., both TV and nonnegativity like
`   x = cuqi.implicitprior.RegularizedGaussian(np.zeros(5), 1,
                                                regularization = "tv", strength = 5,
                                                constraint = "nonnegativity")`
Works with Gibbs and conjugacy.

