### PR TITLE
Robust automatic sampler selection/suggestion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ dist/
 
 # Ignore certain files from demos
 */CUQI_samples/*
+*.ipynb

--- a/cuqi/experimental/mcmc/__init__.py
+++ b/cuqi/experimental/mcmc/__init__.py
@@ -120,4 +120,4 @@ from ._gibbs import HybridGibbs
 from ._conjugate import Conjugate
 from ._conjugate_approx import ConjugateApprox
 from ._direct import Direct
-from ._utilities import find_valid_samplers, find_valid_sampling_strategy
+from ._utilities import find_valid_samplers, find_valid_sampling_strategy, suggest_sampler, suggest_sampling_strategy

--- a/cuqi/experimental/mcmc/__init__.py
+++ b/cuqi/experimental/mcmc/__init__.py
@@ -120,4 +120,4 @@ from ._gibbs import HybridGibbs
 from ._conjugate import Conjugate
 from ._conjugate_approx import ConjugateApprox
 from ._direct import Direct
-from ._utilities import find_valid_samplers
+from ._utilities import find_valid_samplers, find_valid_sampling_strategy

--- a/cuqi/experimental/mcmc/_utilities.py
+++ b/cuqi/experimental/mcmc/_utilities.py
@@ -88,3 +88,28 @@ def suggest_sampler(target, as_string = True):
                 return suggestion
             
     return None
+
+def suggest_sampling_strategy(target):
+    """
+        Suggests a possible sampling strategy to be used with the HybridGibbs sampler.
+
+        For reasoning behind the suggestion, see 'suggest_sampler'.
+    """
+
+    if not isinstance(target, cuqi.distribution.JointDistribution):
+        return None
+
+    par_names = target.get_parameter_names()
+
+    suggested_samplers = dict()
+    for par_name in par_names:
+        conditional_params = {par_name_: np.ones(target.dim[i]) for i, par_name_ in enumerate(par_names) if par_name_ != par_name}
+        conditional = target(**conditional_params)
+
+        sampler = suggest_sampler(conditional, as_string = True)
+        if sampler is None:
+            return None
+        
+        suggested_samplers[par_name] = sampler
+
+    return suggested_samplers

--- a/cuqi/experimental/mcmc/_utilities.py
+++ b/cuqi/experimental/mcmc/_utilities.py
@@ -6,7 +6,7 @@ import numpy as np
 import cuqi.experimental.mcmc as samplers 
 
 def find_valid_samplers(target, as_string = True):
-        """
+    """
         Finds all possible sampleras that can be used for sampling from the target distribution.
 
         Parameters

--- a/cuqi/experimental/mcmc/_utilities.py
+++ b/cuqi/experimental/mcmc/_utilities.py
@@ -6,7 +6,19 @@ import numpy as np
 import cuqi.experimental.mcmc as samplers 
 
 def find_valid_samplers(target, as_string = True):
-    """ Finds all samplers in the cuqi.experimental.mcmc module that accept the provided target. """
+        """
+        Finds all possible sampleras that can be used for sampling from the target distribution.
+
+        Parameters
+        ----------
+
+        target : `cuqi.distribution.Distribution`
+            The target distribution to sample.
+        
+        as_string : boolean
+            Whether to return the name of the sampler as a string instead of instantiating a sampler. *Optional*
+
+    """
 
     all_samplers = [(name, cls) for name, cls in inspect.getmembers(cuqi.experimental.mcmc, inspect.isclass) if issubclass(cls, cuqi.experimental.mcmc.Sampler)]
     valid_samplers = []
@@ -26,7 +38,19 @@ def find_valid_samplers(target, as_string = True):
 
 def find_valid_sampling_strategy(target, as_string = True):
     """
-        Find valid samplers to be used for creating a sampling strategy for the HybridGibbs sampler
+        Find all possible sampling strategies to be used with the HybridGibbs sampler.
+        Returns None if no sampler could be suggested for at least one conditional distribution.
+
+        Parameters
+        ----------
+
+        target : `cuqi.distribution.JointDistribution`
+            The target distribution to find a valid sampler strategy for.
+        
+        as_string : boolean
+            Whether to return the name of the samplers in the sampling strategy as a string instead of instantiating samplers. *Optional*
+    
+
     """
 
     if not isinstance(target, cuqi.distribution.JointDistribution):
@@ -50,8 +74,20 @@ def find_valid_sampling_strategy(target, as_string = True):
 def suggest_sampler(target, as_string = False, exceptions = []):
     """
         Suggests a possible sampler that can be used for sampling from the target distribution.
+        Return None if no sampler could be suggested.
 
-        TODO: DESCRIBE ARGUMENTS BEHIND SUGGESTION
+        Parameters
+        ----------
+
+        target : `cuqi.distribution.Distribution`
+            The target distribution to sample.
+        
+        as_string : boolean
+            Whether to return the name of the sampler as a string instead of instantiating a sampler. *Optional*
+    
+        exceptions : list of cuqi.experimental.mcmc sampler classes
+            Samplers not to consider for suggestion. *Optional*
+
     """
 
     # TODO: Conditions for suggestions, e.g., only use CWMH when the dimension of the problem is low
@@ -96,8 +132,17 @@ def suggest_sampler(target, as_string = False, exceptions = []):
 def suggest_sampling_strategy(target, as_string = False):
     """
         Suggests a possible sampling strategy to be used with the HybridGibbs sampler.
+        Returns None if no sampler could be suggested for at least one conditional distribution.
 
-        For reasoning behind the suggestion, see 'suggest_sampler'.
+        Parameters
+        ----------
+
+        target : `cuqi.distribution.JointDistribution`
+            The target distribution get a sampling strategy for.
+        
+        as_string : boolean
+            Whether to return the name of the samplers in the sampling strategy as a string instead of instantiating samplers. *Optional*
+    
     """
 
     if not isinstance(target, cuqi.distribution.JointDistribution):

--- a/cuqi/experimental/mcmc/_utilities.py
+++ b/cuqi/experimental/mcmc/_utilities.py
@@ -51,10 +51,11 @@ def suggest_sampler(target, as_string = False, exceptions = []):
     """
         Suggests a possible sampler that can be used for sampling from the target distribution.
 
-        DESCRIBE ARGUMENTS BEHIND SUGGESTION
+        TODO: DESCRIBE ARGUMENTS BEHIND SUGGESTION
     """
 
-    n = target.dim
+    # TODO: Conditions for suggestions, e.g., only use CWMH when the dimension of the problem is low
+    # TODO: Discuss ordering
 
     # Samplers with suggested default values (when no defaults are defined)
     ordering = [
@@ -66,15 +67,14 @@ def suggest_sampler(target, as_string = False, exceptions = []):
         (samplers.LinearRTO, {}),
         (samplers.RegularizedLinearRTO, {}),
         (samplers.UGLA, {}),
-        # Hamiltonian samplers
+        # Gradient.based samplers (Hamiltonian and Langevin)
         (samplers.NUTS, {}),
-        # Langevin based samplers
         (samplers.MALA, {}),
         (samplers.ULA, {}),
         # Gibbs and Componentwise samplers
-        (samplers.HybridGibbs, {}),
-        (samplers.CWMH, {"scale" : 0.05*np.ones(n),
-                         "x0" : 0.5*np.ones(n)}),
+        (samplers.HybridGibbs, {"sampling_strategy" : suggest_sampling_strategy(target, as_string = False)}),
+        (samplers.CWMH, {"scale" : 0.05*np.ones(target.dim),
+                         "x0" : 0.5*np.ones(target.dim)}),
         # Proposal based samplers
         (samplers.PCN, {"scale" : 0.02}),
         (samplers.MH, {}),
@@ -88,13 +88,9 @@ def suggest_sampler(target, as_string = False, exceptions = []):
             if as_string:
                 return suggestion.__name__
             else:
-                # Cases for samplers that might need default values
-                if suggestion is not samplers.HybridGibbs:
-                    return suggestion(target, **values)
-                else:
-                    return suggestion(target, sampling_strategy = suggest_sampling_strategy(target, as_string = False))
+                return suggestion(target, **values)
 
-            
+    # No sampler can be suggested
     return None
 
 def suggest_sampling_strategy(target, as_string = False):

--- a/cuqi/experimental/mcmc/_utilities.py
+++ b/cuqi/experimental/mcmc/_utilities.py
@@ -1,5 +1,6 @@
 import cuqi
 import inspect
+import numpy as np
 
 def find_valid_samplers(target):
     """ Finds all samplers in the cuqi.experimental.mcmc module that accept the provided target. """
@@ -13,5 +14,34 @@ def find_valid_samplers(target):
             valid_samplers += [name]
         except:
             pass
+
+    # Need a separate case for HybridGibbs
+    if find_valid_sampling_strategy(target) is not None:
+        valid_samplers += [cuqi.experimental.mcmc.HybridGibbs.__name__]
+
+    return valid_samplers
+
+def find_valid_sampling_strategy(target):
+    """
+        Find valid samplers to be used for creating a sampling strategy for the HybridGibbs sampler
+    """
+
+    if not isinstance(target, cuqi.distribution.JointDistribution):
+        return None
+
+    par_names = target.get_parameter_names()
+    print(par_names)
+
+    valid_samplers = dict()
+    for par_name in par_names:
+        # TODO: Compute conditional distribution
+        conditional_params = {par_name_: np.ones(target.dim[i]) for i, par_name_ in enumerate(par_names) if par_name_ != par_name}
+        conditional = target(**conditional_params)
+
+        samplers = find_valid_samplers(conditional)
+        if len(samplers) == 0:
+            return None
+        
+        valid_samplers[par_name] = samplers
 
     return valid_samplers

--- a/cuqi/experimental/mcmc/_utilities.py
+++ b/cuqi/experimental/mcmc/_utilities.py
@@ -34,7 +34,6 @@ def find_valid_sampling_strategy(target):
 
     valid_samplers = dict()
     for par_name in par_names:
-        # TODO: Compute conditional distribution
         conditional_params = {par_name_: np.ones(target.dim[i]) for i, par_name_ in enumerate(par_names) if par_name_ != par_name}
         conditional = target(**conditional_params)
 

--- a/cuqi/experimental/mcmc/_utilities.py
+++ b/cuqi/experimental/mcmc/_utilities.py
@@ -30,7 +30,6 @@ def find_valid_sampling_strategy(target):
         return None
 
     par_names = target.get_parameter_names()
-    print(par_names)
 
     valid_samplers = dict()
     for par_name in par_names:

--- a/cuqi/experimental/mcmc/_utilities.py
+++ b/cuqi/experimental/mcmc/_utilities.py
@@ -2,7 +2,10 @@ import cuqi
 import inspect
 import numpy as np
 
-def find_valid_samplers(target):
+# This import makes suggest_sampler easier to read
+import cuqi.experimental.mcmc as samplers 
+
+def find_valid_samplers(target, as_string = True):
     """ Finds all samplers in the cuqi.experimental.mcmc module that accept the provided target. """
 
     all_samplers = [(name, cls) for name, cls in inspect.getmembers(cuqi.experimental.mcmc, inspect.isclass) if issubclass(cls, cuqi.experimental.mcmc.Sampler)]
@@ -11,17 +14,17 @@ def find_valid_samplers(target):
     for name, sampler in all_samplers:
         try:
             sampler(target)
-            valid_samplers += [name]
+            valid_samplers += [name if as_string else sampler]
         except:
             pass
 
     # Need a separate case for HybridGibbs
     if find_valid_sampling_strategy(target) is not None:
-        valid_samplers += [cuqi.experimental.mcmc.HybridGibbs.__name__]
+        valid_samplers += [cuqi.experimental.mcmc.HybridGibbs.__name__ if as_string else cuqi.experimental.mcmc.HybridGibbs]
 
     return valid_samplers
 
-def find_valid_sampling_strategy(target):
+def find_valid_sampling_strategy(target, as_string = True):
     """
         Find valid samplers to be used for creating a sampling strategy for the HybridGibbs sampler
     """
@@ -36,10 +39,52 @@ def find_valid_sampling_strategy(target):
         conditional_params = {par_name_: np.ones(target.dim[i]) for i, par_name_ in enumerate(par_names) if par_name_ != par_name}
         conditional = target(**conditional_params)
 
-        samplers = find_valid_samplers(conditional)
+        samplers = find_valid_samplers(conditional, as_string)
         if len(samplers) == 0:
             return None
         
         valid_samplers[par_name] = samplers
 
     return valid_samplers
+
+def suggest_sampler(target, as_string = True):
+    """
+        Suggests a possible sampler that can be used for sampling from the target distribution.
+
+        DESCRIBE ARGUMENTS BEHIND SUGGESTION
+    """
+
+    ordering = [
+        # Direct and Conjugate samplers
+        samplers.Direct,
+        samplers.Conjugate,
+        samplers.ConjugateApprox,
+        # Specialized samplers
+        samplers.LinearRTO,
+        samplers.RegularizedLinearRTO,
+        samplers.UGLA,
+        # Hamiltonian samplers
+        samplers.NUTS,
+        # Langevin based samplers
+        samplers.MALA,
+        samplers.ULA,
+        # Gibbs and Componentwise samplers
+        samplers.HybridGibbs,
+        samplers.CWMH,
+        # Proposal based samplers
+        samplers.PCN,
+        samplers.MH,
+    ]
+
+    valid_samplers = find_valid_samplers(target, as_string = False)
+    
+    for suggestion in ordering:
+        if suggestion in valid_samplers:
+            # Sampler found
+            if as_string:
+                return suggestion.__name__
+            else: 
+                # TODO: Instantiate if possible
+                return suggestion
+            
+    return None


### PR DESCRIPTION
This PR implements a robust method for automatically selecting and instantiating a sampler given a distribution, when possible.
It makes a suggestion based a predefined ordered list of sampler classes and finds the first valid ones. (Also works with HybridGibbs.)

This could be used to rework `sample_posterior` from `BayesianProblem` (only for the experimental samplers) to make it more maintainable by removing long if/else-chains. Could also help with Issues #505 #195 #95 

Called it `suggest_sampler` to insinuate that it is only a suggestion and might not be the best sampler for the given distribution.

Example:
![image](https://github.com/user-attachments/assets/e0400ce8-39ed-42fa-9d32-817d5bc36e97)

The created sampler is a HybridGibbs sampler with Conjugacy and UGLA.

To-do's:
- [ ] Write an issue with DoD
- [ ] Discuss ordering of samplers
- [ ] Add conditions such that some samplers are perhaps only suggested on sufficiently small problems.
- [ ] Tests
