### PR TITLE
Fix NumPy 2.0.0 support

### DIFF
--- a/cuqi/distribution/_truncated_normal.py
+++ b/cuqi/distribution/_truncated_normal.py
@@ -37,7 +37,7 @@ class TruncatedNormal(Distribution):
         p = cuqi.distribution.TruncatedNormal(mean=0, std=1, low=-2, high=2)
         samples = p.sample(5000)
     """
-    def __init__(self, mean=None, std=None, low=-np.Inf, high=np.Inf, is_symmetric=False, **kwargs):
+    def __init__(self, mean=None, std=None, low=-np.inf, high=np.inf, is_symmetric=False, **kwargs):
         # Init from abstract distribution class
         super().__init__(is_symmetric=is_symmetric, **kwargs)  
 


### PR DESCRIPTION
Replace removed Numpy alias such that CUQIpy now support NumPy version 2.0.0. (Tested it with version 2.0.2, but not extensively)

Fixed #633

Perhaps consider having some tests with more recent versions of foundational packages?