### PR TITLE
Fix hybrid gibbs ordering

### DIFF
--- a/cuqi/experimental/mcmc/_gibbs.py
+++ b/cuqi/experimental/mcmc/_gibbs.py
@@ -134,7 +134,7 @@ class HybridGibbs:
         self._scan_order = scan_order
 
         # Check that the parameters of the target align with the sampling_strategy and scan_order
-        if set(self.par_names) != set(self._scan_order):
+        if set(self.par_names) != set(self.scan_order):
             raise ValueError("Parameter names in JointDistribution do not equal the names in the scan order.")
 
         # Initialize sampler (after target is set)

--- a/cuqi/experimental/mcmc/_gibbs.py
+++ b/cuqi/experimental/mcmc/_gibbs.py
@@ -61,6 +61,10 @@ class HybridGibbs:
         will call its step method in each Gibbs step.
         Default is 1 for all variables.
 
+    scan_order : list, *optional*
+        Order in which the conditional distributions are sampled.
+        If not specified, it will be the order in the sampling_strategy
+
     callback : callable, optional
         A function that will be called after each sampling step. It can be useful for monitoring the sampler during sampling.
         The function should take three arguments: the sampler object, the index of the current sampling step, the total number of requested samples. The last two arguments are integers. An example of the callback function signature is: `callback(sampler, sample_index, num_of_samples)`.
@@ -110,7 +114,7 @@ class HybridGibbs:
             
     """
 
-    def __init__(self, target: JointDistribution, sampling_strategy: Dict[str, Sampler], num_sampling_steps: Dict[str, int] = None, callback=None):
+    def __init__(self, target: JointDistribution, sampling_strategy: Dict[str, Sampler], num_sampling_steps: Dict[str, int] = None, scan_order = None, callback=None):
 
         # Store target and allow conditioning to reduce to a single density
         self.target = target() # Create a copy of target distribution (to avoid modifying the original)
@@ -124,10 +128,13 @@ class HybridGibbs:
         # Store parameter names
         self.par_names = self.target.get_parameter_names()
 
-        # Check that the parameters of the target align with the sampling_strategy
+        # Store the scan order
+        self._scan_order = scan_order
+
+        # Check that the parameters of the target align with the sampling_strategy and scan_order
         for par_name in self.par_names:
-            if par_name not in self.samplers.keys():
-                raise ValueError("Parameter '{}' does not have a sampler in sampling_strategy.".format(par_name))
+            if par_name not in self.samplers.keys() or par_name not in self.scan_order:
+                raise ValueError("Parameter '{}' does not have a sampler in sampling_strategy or scan_order.".format(par_name))
 
         # Initialize sampler (after target is set)
         self._initialize()
@@ -155,6 +162,13 @@ class HybridGibbs:
 
         # Validate all targets for samplers.
         self.validate_targets()
+
+
+    @property
+    def scan_order(self):
+        if self._scan_order is None:
+            return list(self.samplers.keys())
+        return self._scan_order
 
     # ------------ Public methods ------------
     def validate_targets(self):
@@ -225,7 +239,7 @@ class HybridGibbs:
         """ Sequentially go through all parameters and sample them conditionally on each other """
 
         # Sample from each conditional distribution
-        for par_name in self.samplers.keys():
+        for par_name in self.scan_order:
 
             # Set target for current parameter
             self._set_target(par_name)

--- a/cuqi/experimental/mcmc/_gibbs.py
+++ b/cuqi/experimental/mcmc/_gibbs.py
@@ -61,9 +61,10 @@ class HybridGibbs:
         will call its step method in each Gibbs step.
         Default is 1 for all variables.
 
-    scan_order : list, *optional*
+    scan_order : list or str, *optional*
         Order in which the conditional distributions are sampled.
-        If not specified, it will be the order in the sampling_strategy
+        If set to "random", use a random ordering at each step.
+        If not specified, it will be the order in the sampling_strategy.
 
     callback : callable, optional
         A function that will be called after each sampling step. It can be useful for monitoring the sampler during sampling.
@@ -133,7 +134,7 @@ class HybridGibbs:
 
         # Check that the parameters of the target align with the sampling_strategy and scan_order
         for par_name in self.par_names:
-            if par_name not in self.samplers.keys() or par_name not in self.scan_order:
+            if par_name not in self.scan_order:
                 raise ValueError("Parameter '{}' does not have a sampler in sampling_strategy or scan_order.".format(par_name))
 
         # Initialize sampler (after target is set)
@@ -163,11 +164,14 @@ class HybridGibbs:
         # Validate all targets for samplers.
         self.validate_targets()
 
-
     @property
     def scan_order(self):
         if self._scan_order is None:
             return list(self.samplers.keys())
+        if self._scan_order == "random":
+            arr = list(self.samplers.keys())
+            np.random.shuffle(arr) # Shuffle works in-place
+            return arr
         return self._scan_order
 
     # ------------ Public methods ------------

--- a/cuqi/experimental/mcmc/_gibbs.py
+++ b/cuqi/experimental/mcmc/_gibbs.py
@@ -217,7 +217,7 @@ class HybridGibbs:
         """ Sequentially go through all parameters and sample them conditionally on each other """
 
         # Sample from each conditional distribution
-        for par_name in self.par_names:
+        for par_name in self.samplers.keys():
 
             # Set target for current parameter
             self._set_target(par_name)

--- a/cuqi/experimental/mcmc/_gibbs.py
+++ b/cuqi/experimental/mcmc/_gibbs.py
@@ -121,6 +121,11 @@ class HybridGibbs:
         # Store parameter names
         self.par_names = self.target.get_parameter_names()
 
+        # Check that the parameters of the target align with the sampling_strategy
+        for par_name in self.par_names:
+            if par_name not in self.samplers.keys():
+                raise ValueError("Parameter '{}' does not have a sampler in sampling_strategy.".format(par_name))
+
         # Initialize sampler (after target is set)
         self._initialize()
 

--- a/cuqi/experimental/mcmc/_gibbs.py
+++ b/cuqi/experimental/mcmc/_gibbs.py
@@ -43,7 +43,8 @@ class HybridGibbs:
     their internal state between Gibbs steps.
 
     The order in which the conditionals are sampled is the order of the
-    variables in the sampling strategy.
+    variables in the sampling strategy, unless a different sampling order
+    is specified by the parameter `scan_order`
 
     Parameters
     ----------

--- a/cuqi/experimental/mcmc/_gibbs.py
+++ b/cuqi/experimental/mcmc/_gibbs.py
@@ -134,9 +134,8 @@ class HybridGibbs:
         self._scan_order = scan_order
 
         # Check that the parameters of the target align with the sampling_strategy and scan_order
-        for par_name in self.par_names:
-            if par_name not in self.scan_order:
-                raise ValueError("Parameter '{}' does not have a sampler in sampling_strategy or scan_order.".format(par_name))
+        if set(self.par_names) != set(self._scan_order):
+            raise ValueError("Parameter names in JointDistribution do not equal the names in the scan order.")
 
         # Initialize sampler (after target is set)
         self._initialize()

--- a/cuqi/experimental/mcmc/_gibbs.py
+++ b/cuqi/experimental/mcmc/_gibbs.py
@@ -42,6 +42,9 @@ class HybridGibbs:
     fully stateful at this point. This means samplers like NUTS will lose
     their internal state between Gibbs steps.
 
+    The order in which the conditionals are sampled is the order of the
+    variables in the sampling strategy.
+
     Parameters
     ----------
     target : cuqi.distribution.JointDistribution

--- a/tests/test_implicit_priors.py
+++ b/tests/test_implicit_priors.py
@@ -210,8 +210,8 @@ def test_regression_increasing():
     posterior = joint(y=y_obs)
    
     sampling_strategy = {
+        'd': cuqi.experimental.mcmc.Conjugate(),
         'x': cuqi.experimental.mcmc.RegularizedLinearRTO(maxit=50, penalty_parameter=20, adaptive = False),
-        'd': cuqi.experimental.mcmc.Conjugate()
                         }
     sampler = cuqi.experimental.mcmc.HybridGibbs(posterior, sampling_strategy)
 
@@ -241,8 +241,8 @@ def test_regression_convex():
     posterior = joint(y=y_obs)
    
     sampling_strategy = {
-        'x': cuqi.experimental.mcmc.RegularizedLinearRTO(maxit=50, penalty_parameter=20, adaptive = False),
-        'd': cuqi.experimental.mcmc.Conjugate()
+        'd': cuqi.experimental.mcmc.Conjugate(),
+        'x': cuqi.experimental.mcmc.RegularizedLinearRTO(maxit=50, penalty_parameter=20, adaptive = False)
                         }
     sampler = cuqi.experimental.mcmc.HybridGibbs(posterior, sampling_strategy)
 

--- a/tests/zexperimental/test_mcmc.py
+++ b/tests/zexperimental/test_mcmc.py
@@ -1653,5 +1653,5 @@ def test_gibbs_scan_order():
                 "s": cuqi.experimental.mcmc.Conjugate(),
             }
     
-    sampler = cuqi.experimental.mcmc.HybridGibbs(target, sampling_strategy, scan_order=['x', 'd'])
-    assert sampler.scan_order == ['x', 'd']
+    sampler = cuqi.experimental.mcmc.HybridGibbs(target, sampling_strategy, scan_order=['x', 's'])
+    assert sampler.scan_order == ['x', 's']

--- a/tests/zexperimental/test_mcmc.py
+++ b/tests/zexperimental/test_mcmc.py
@@ -1633,3 +1633,25 @@ def test_all_samplers_that_should_be_tested_for_callback_are_in_the_tested_list(
         assert cls in tested_classes, f"Sampler {cls} is not tested for callback."
 
 # ============= End testing sampler callback =============
+def test_gibbs_random_scan_order():
+    target = HybridGibbs_target_1()
+    sampling_strategy={
+                "x": cuqi.experimental.mcmc.LinearRTO(),
+                "s": cuqi.experimental.mcmc.Conjugate(),
+            }
+    
+    sampler = cuqi.experimental.mcmc.HybridGibbs(target, sampling_strategy, scan_order='random')
+    np.random.seed(0)
+    scan_order1 = sampler.scan_order
+    scan_order2 = sampler.scan_order
+    assert scan_order1 != scan_order2
+
+def test_gibbs_scan_order():
+    target = HybridGibbs_target_1()
+    sampling_strategy={
+                "x": cuqi.experimental.mcmc.LinearRTO(),
+                "s": cuqi.experimental.mcmc.Conjugate(),
+            }
+    
+    sampler = cuqi.experimental.mcmc.HybridGibbs(target, sampling_strategy, scan_order=['x', 'd'])
+    assert sampler.scan_order == ['x', 'd']


### PR DESCRIPTION
Changes the ordering of the sampler in `HybridGibbs` to the order of the sampling_strategy instead of the order in which the posterior was constructed.

Closes #657 

With scan_order:
Closes #441
