### PR TITLE
Config Sphinx to display links to source codes

### DIFF
--- a/cuqi/distribution/_uniform.py
+++ b/cuqi/distribution/_uniform.py
@@ -67,7 +67,6 @@ class UnboundedUniform(Distribution):
     -inf and inf, respectively. This distribution is not normalizable,
     and therefore cannot be sampled from. It is mainly used for
     initializing non-informative priors.
-    
     Parameters
     ----------
     geometry : int or Geometry


### PR DESCRIPTION
fixed #698 

Now we have a "source" button linking to the source code:

<img width="787" height="336" alt="Screenshot 2025-10-20 at 13 25 00" src="https://github.com/user-attachments/assets/acf61d09-ad98-4371-8d61-d879c5740882" />

