### PR TITLE
Add Python 3.13 and 3.14 to CI test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest] # Add windows-latest, macos-latest to test on multiple OS
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest] # Add windows-latest, macos-latest to test on multiple OS
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest] # Add windows-latest, macos-latest to test on multiple OS
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      # fail-fast: false
       matrix:
         os: [ubuntu-latest] # Add windows-latest, macos-latest to test on multiple OS
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]

--- a/tests/test_bayesian_inversion.py
+++ b/tests/test_bayesian_inversion.py
@@ -69,8 +69,8 @@ def test_TP_BayesianProblem_sample(copy_reference, TP_type, phantom, prior, Ns, 
     # Check results with reference data
     assert med_xpos == pytest.approx(ref["median"], rel=1e-3, abs=1e-6)
     assert sigma_xpos == pytest.approx(ref["sigma"], rel=1e-3, abs=1e-6)
-    assert lo95 == pytest.approx(ref["lo95"], rel=1e-3, abs=1e-6)
-    assert up95 == pytest.approx(ref["up95"], rel=1e-3, abs=1e-6)
+    assert lo95 == pytest.approx(ref["lo95"], rel=1e-3, abs=1e-5)
+    assert up95 == pytest.approx(ref["up95"], rel=1e-3, abs=1e-5)
 
 @pytest.mark.parametrize("legacy", [True, False])
 @pytest.mark.parametrize("TP_type, phantom, priors, Ns",


### PR DESCRIPTION
Fix #740